### PR TITLE
fix:牌堆上传

### DIFF
--- a/src/components/mod/PageMiscDeck.vue
+++ b/src/components/mod/PageMiscDeck.vue
@@ -7,7 +7,7 @@
           class="upload"
           action=""
           multiple
-          accept="application/json, .yaml, .yml, .deck"
+
           :before-upload="beforeUpload"
           :file-list="fileList"
         >


### PR DESCRIPTION
![W5H$LEX`(HG2IYYYTU(9G H_tmb](https://github.com/sealdice/sealdice-ui/assets/109738656/ae1dd92c-7a0a-42d4-bfc6-f2a69224bb3b)
如图，在安卓手机上不知道是 element 组件的问题还是系统文件选择器的问题，yml、deck 被识别为 bin 无法被选中上传。