### PR TITLE
fix:修复了分离部署gocq账号时的表单缺失属性与显示不规整

### DIFF
--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -704,6 +704,7 @@ const form = reactive({
 
   relWorkDir: '',
   connectUrl: '',
+  accessToken: '',
 })
 
 const addOne = () => {

--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -234,12 +234,12 @@
         <el-form-item v-if="form.accountType === 6" label="账号" :label-width="formLabelWidth" required>
           <el-input v-model="form.account" type="number" autocomplete="off"></el-input>
         </el-form-item>
-        <el-form-item v-if="form.accountType === 6" label="gocqhttp目录" :label-width="formLabelWidth" required>
-          <el-input v-model="form.relWorkDir" type="text" autocomplete="off" placeholder="d:/my-gocqhttp"></el-input>
+        <el-form-item v-if="form.accountType === 6" label="程序目录" :label-width="formLabelWidth" required>
+          <el-input v-model="form.relWorkDir" type="text" autocomplete="off" placeholder="gocqhttp的程序目录，如 d:/my-gocqhttp"></el-input>
         </el-form-item>
-        <el-form-item v-if="form.accountType === 6" label="正向WS连接地址" :label-width="formLabelWidth" required>
-          <el-input v-model="form.connectUrl" placeholder="ws://localhost:1234" type="text" autocomplete="off"></el-input>
-        </el-form-item>
+        <el-form-item v-if="form.accountType === 6" label="连接地址" :label-width="formLabelWidth" required>
+          <el-input v-model="form.connectUrl" placeholder="正向WS连接地址，如 ws://localhost:1234" type="text" autocomplete="off"></el-input>
+        </el-form-item>  
         <el-form-item v-if="form.accountType === 6" label="访问令牌" :label-width="formLabelWidth">
           <el-input v-model="form.accessToken" placeholder="gocqhttp配置的access token，没有不用填写" type="text" autocomplete="off"></el-input>
         </el-form-item>


### PR DESCRIPTION
- 修复添加分离部署gocq的账号时，表单form缺失属性access token导致的bulid错误
- 修复gocqhttp分离部署时，配置项显示不规整的问题，调整了部分样式
现在的样式如下
![image](https://github.com/sealdice/sealdice-ui/assets/73411104/f158e2c6-5026-4ca4-8062-149e1b4631b3)
