### PR TITLE
fix: 修复当页面宽度恰为640px时菜单栏和菜单按钮都不显示的问题

### DIFF
--- a/src/Main.vue
+++ b/src/Main.vue
@@ -345,7 +345,7 @@ body {
   height: 100%;
 }
 
-@media screen and (width <= 640px) {
+@media screen and (max-width: 639.9px) {
   .nav {
     padding: 0 0.5rem 0 0;
   }
@@ -363,7 +363,7 @@ body {
   }
 }
 
-@media screen and (width > 640px) {
+@media screen and (min-width: 640px) {
   .nav {
     padding: 0 1rem 0 1.5rem;
   }

--- a/src/Main.vue
+++ b/src/Main.vue
@@ -345,7 +345,7 @@ body {
   height: 100%;
 }
 
-@media screen and (max-width: 640px) {
+@media screen and (width <= 640px) {
   .nav {
     padding: 0 0.5rem 0 0;
   }
@@ -354,14 +354,22 @@ body {
     display: none;
   }
 
+  .menu-button-wrapper {
+    display: block;
+  }
+
   .main-container {
     padding: 1rem;
   }
 }
 
-@media screen and (min-width: 640px) {
+@media screen and (width > 640px) {
   .nav {
     padding: 0 1rem 0 1.5rem;
+  }
+
+  .menu {
+    display: block;
   }
 
   .menu-button-wrapper {


### PR DESCRIPTION
两个commits用了两种写法，第一个的commit a1e75b6 中使用的 `@media screen and (width > 640px)` 的浏览器支持情况如下：
✅ Chrome 104+ (2022年8月)
✅ Firefox 103+ (2022年7月)
✅ Safari 15.4+ (2022年3月)
✅ Edge 104+ (基于Chromium)
❌ IE 不支持

第二个commit c36326a 改为了传统写法，但在页面宽度由于DPR产生的子像素计算误差卡在 639.9px到640px之间时，侧边菜单栏和菜单按钮会同时显示
