### PR TITLE
将【新建账户——QQ（ob11正向WS）】一栏的”访问令牌“提示中已经过时的“gocq中配置”这一登录方式改为NapCat这一更为流行且需要该token的登录方式

### DIFF
--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -1305,7 +1305,7 @@
         <el-form-item v-if="form.accountType === 6" label="访问令牌" :label-width="formLabelWidth">
           <el-input
             v-model="form.accessToken"
-            placeholder="gocqhttp配置的access token，没有不用填写"
+            placeholder="NapCat中配置的access token，没有不用填写"
             type="text"
             autocomplete="off"></el-input>
         </el-form-item>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Refresh the access token placeholder text for QQ (ob11 WebSocket) accounts to align with the current NapCat-based login approach.