### PR TITLE
chore: 修改Minecraft服务器相关描述和提示

### DIFF
--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -1606,14 +1606,20 @@
             <ul style="margin: 0.25rem 0 0 1.2rem; padding: 0">
               <li>
                 前往
-                <a href="https://github.com/sealdice/sealdice-minecraft/releases/latest" target="_blank"
+                <a
+                  href="https://github.com/sealdice/sealdice-minecraft/releases/latest"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   >GitHub Releases</a
                 >
                 下载最新 mc 插件，并安装到 mc 服务器中。
               </li>
               <li>
                 详细使用说明：
-                <a href="https://github.com/sealdice/sealdice-minecraft#readme" target="_blank"
+                <a
+                  href="https://github.com/sealdice/sealdice-minecraft#readme"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   >ReadMe</a
                 >
               </li>
@@ -1622,16 +1628,27 @@
             <ul style="margin: 0.25rem 0 0 1.2rem; padding: 0">
               <li>
                 从
-                <a href="https://www.curseforge.com/minecraft/mc-mods/sealdice2mc" target="_blank"
+                <a
+                  href="https://www.curseforge.com/minecraft/mc-mods/sealdice2mc"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   >CurseForge</a
                 >
                 或
-                <a href="https://modrinth.com/mod/sealdice2mc" target="_blank">Modrinth</a>
+                <a
+                  href="https://modrinth.com/mod/sealdice2mc"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Modrinth</a
+                >
                 下载 SealDice2MC 模组，安装在服务端（或局域网联机的主机端）。
               </li>
               <li>
                 详细使用说明：
-                <a href="https://github.com/Dontplay0112/Sealdice2MC#readme" target="_blank"
+                <a
+                  href="https://github.com/Dontplay0112/Sealdice2MC#readme"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   >ReadMe</a
                 >
               </li>

--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -779,7 +779,7 @@
             <el-option label="KOOK(开黑啦)" :value="ImConnectionTypeKook"></el-option>
             <el-option label="Telegram" :value="ImConnectionTypeTelegram"></el-option>
             <el-option
-              label="Minecraft服务器(Paper)"
+              label="Minecraft服务器"
               :value="ImConnectionTypeMinecraft"></el-option>
             <el-option label="Dodo语音" :value="ImConnectionTypeDodo"></el-option>
             <el-option label="钉钉" :value="ImConnectionTypeDingTalk"></el-option>
@@ -1598,12 +1598,44 @@
           required>
           <el-input v-model="form.url" type="string" autocomplete="off"></el-input>
           <small>
-            <div>提示：前往 https://github.com/sealdice/sealdice-minecraft/releases/latest</div>
-            <div>下载最新的 mc 插件然后安装在 mc 服务器中</div>
-            <div>按照 ip:端口 的格式写在框里，默认端口 8887</div>
-            <div>
-              详细的使用说明请阅读 Readme (https://github.com/sealdice/sealdice-minecraft#readme)
-            </div>
+            <div><strong>提示</strong></div>
+            <ul style="margin: 0.25rem 0 0 1.2rem; padding: 0">
+              <li>地址请按 ip:端口 格式填写，默认端口 8887。</li>
+            </ul>
+            <div style="margin-top: 0.35rem"><strong>Paper端 配置方法</strong></div>
+            <ul style="margin: 0.25rem 0 0 1.2rem; padding: 0">
+              <li>
+                前往
+                <a href="https://github.com/sealdice/sealdice-minecraft/releases/latest" target="_blank"
+                  >GitHub Releases</a
+                >
+                下载最新 mc 插件，并安装到 mc 服务器中。
+              </li>
+              <li>
+                详细使用说明：
+                <a href="https://github.com/sealdice/sealdice-minecraft#readme" target="_blank"
+                  >ReadMe</a
+                >
+              </li>
+            </ul>
+            <div style="margin-top: 0.35rem"><strong>fabric/(neo)forge端 配置方法</strong></div>
+            <ul style="margin: 0.25rem 0 0 1.2rem; padding: 0">
+              <li>
+                从
+                <a href="https://www.curseforge.com/minecraft/mc-mods/sealdice2mc" target="_blank"
+                  >CurseForge</a
+                >
+                或
+                <a href="https://modrinth.com/mod/sealdice2mc" target="_blank">Modrinth</a>
+                下载 SealDice2MC 模组，安装在服务端（或局域网联机的主机端）。
+              </li>
+              <li>
+                详细使用说明：
+                <a href="https://github.com/Dontplay0112/Sealdice2MC#readme" target="_blank"
+                  >ReadMe</a
+                >
+              </li>
+            </ul>
           </small>
         </el-form-item>
 

--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -778,9 +778,7 @@
             <el-option label="Discord" :value="ImConnectionTypeDiscord"></el-option>
             <el-option label="KOOK(开黑啦)" :value="ImConnectionTypeKook"></el-option>
             <el-option label="Telegram" :value="ImConnectionTypeTelegram"></el-option>
-            <el-option
-              label="Minecraft服务器"
-              :value="ImConnectionTypeMinecraft"></el-option>
+            <el-option label="Minecraft服务器" :value="ImConnectionTypeMinecraft"></el-option>
             <el-option label="Dodo语音" :value="ImConnectionTypeDodo"></el-option>
             <el-option label="钉钉" :value="ImConnectionTypeDingTalk"></el-option>
             <el-option label="Slack" :value="ImConnectionTypeSlack"></el-option>


### PR DESCRIPTION
- 修改账号类型，“Minecraft服务器(Paper)” -> “Minecraft服务器”
- 修改提示，补充了模组端相关内容

<img width="1290" height="539" alt="SealDiceMCServer" src="https://github.com/user-attachments/assets/218486fe-bffa-4025-8f8a-07c3dc04865e" />

## 由 Sourcery 提供的摘要

更新 Minecraft 连接选项标签，并扩展针对不同服务器类型的配置指南。

新功能：
- 为 Paper 和 fabric/(neo)forge Minecraft 服务器端点添加单独的配置说明，包括下载链接和文档参考。

增强内容：
- 将 Minecraft 服务器连接选项重命名为更通用的标签，而不再局限于 Paper。
- 改进 Minecraft 服务器连接的帮助文本，采用更有结构的格式，并提供更清晰的地址输入说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 Minecraft 服务器连接选项的标签，并扩展针对不同服务器类型的设置指南。

新功能：
- 为 Paper 和 fabric/(neo)forge Minecraft 服务器端点提供单独的配置说明，包括下载来源和文档链接。

改进：
- 将 Minecraft 服务器连接选项重命名为更通用的标签，而不再仅限于 Paper。
- 重构并优化 Minecraft 连接帮助文本，添加格式化提示，并明确说明地址输入的方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Minecraft server connection option labeling and expand setup guidance for different server types.

New Features:
- Provide separate configuration instructions for Paper and fabric/(neo)forge Minecraft server endpoints, including download sources and documentation links.

Enhancements:
- Rename the Minecraft server connection option to a more generic label not limited to Paper.
- Restructure and clarify Minecraft connection help text with formatted tips and explicit address input guidance.

</details>

</details>