### PR TITLE
fix: 修复 iOS 设备无法上传 js/ts 插件的问题

### DIFF
--- a/src/components/mod/PageJs.vue
+++ b/src/components/mod/PageJs.vue
@@ -64,7 +64,7 @@
               <el-upload
                 action=""
                 multiple
-                accept="application/javascript,application/typescript,.js,.ts"
+                accept="*"
                 class="upload"
                 :before-upload="beforeUpload"
                 :file-list="uploadFileList">
@@ -1247,7 +1247,11 @@ const jsShutdown = async () => {
 };
 
 const beforeUpload = async (file: UploadRawFile) => {
-  // UploadRawFile
+  const ext = file.name.split('.').pop()?.toLowerCase();
+  if (ext !== 'js' && ext !== 'ts') {
+    ElMessage.error('仅支持上传 .js 或 .ts 格式的插件文件');
+    return false;
+  }
   const fd = new FormData();
   fd.append('file', file);
   await uploadJs(file);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过将上传的 accept 属性更改为通配符并在代码中验证文件扩展名，修复了在 iOS 上导致 JS/TS 插件上传失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix JS/TS plugin uploads failing on iOS by changing the upload accept attribute to a wildcard and validating file extensions in code.

</details>