### PR TITLE
feat: 指令测试页支持回复分段切换

### DIFF
--- a/src/api/dice/index.ts
+++ b/src/api/dice/index.ts
@@ -30,8 +30,24 @@ export function postMailTest() {
   >('post', 'config/mail_test');
 }
 
-export function postExec(message: string, messageType: 'private' | 'group') {
-  return request('post', 'exec', { message, messageType });
+export function getExecSplitOptions() {
+  return request<ExecSplitOptions>('get', 'exec/split_options');
+}
+
+export function postExec(
+  message: string,
+  messageType: 'private' | 'group',
+  messageSplitLen?: number,
+) {
+  const payload: {
+    message: string;
+    messageType: 'private' | 'group';
+    messageSplitLen?: number;
+  } = { message, messageType };
+  if (messageSplitLen !== undefined) {
+    payload.messageSplitLen = messageSplitLen;
+  }
+  return request('post', 'exec', payload);
 }
 
 export function postUploadToUpgrade(files: Blob) {
@@ -103,6 +119,19 @@ type ExtensionSettings = {
   autoActive: boolean; // 是否自动激活
   disabledCommand: { [key: string]: boolean }; // 禁用的命令
   loaded: boolean; // 是否加载
+};
+
+export type ExecSplitOptionKey = 'short' | 'qq' | 'unlimited';
+
+export type ExecSplitOption = {
+  key: ExecSplitOptionKey;
+  label: string;
+  messageSplitLen: number;
+};
+
+export type ExecSplitOptions = {
+  defaultKey: ExecSplitOptionKey;
+  options: ExecSplitOption[];
 };
 
 type RecentMsg = {

--- a/src/components/tool/PageTest.vue
+++ b/src/components/tool/PageTest.vue
@@ -90,11 +90,11 @@ const fallbackSplitOptions: ExecSplitOption[] = [
 ];
 const splitOptions = ref<ExecSplitOption[]>(fallbackSplitOptions);
 const splitOptionsSupported = ref(true);
-const splitKey = ref<ExecSplitOptionKey>('short');
+const splitKey = ref<ExecSplitOptionKey>('qq');
 const selectedSplitLen = computed(
   () =>
     splitOptions.value.find(option => option.key === splitKey.value)?.messageSplitLen ??
-    fallbackSplitOptions[0].messageSplitLen,
+    fallbackSplitOptions[1].messageSplitLen,
 );
 
 let timerMsg: number;

--- a/src/components/tool/PageTest.vue
+++ b/src/components/tool/PageTest.vue
@@ -1,7 +1,15 @@
 <template>
   <div class="flex flex-col h-full">
-    <div class="mb-3 flex justify-end">
-      <div class="flex justify-center">
+    <div class="mb-3 flex flex-wrap items-center justify-end gap-3">
+      <div class="flex items-center">
+        <el-text class="mr-1.5">分段：</el-text>
+        <el-radio-group v-model="splitKey" size="small">
+          <el-radio-button v-for="option in splitOptions" :key="option.key" :value="option.key">
+            {{ option.label }}
+          </el-radio-button>
+        </el-radio-group>
+      </div>
+      <div class="flex items-center">
         <el-text>测试模式：</el-text>
         <el-radio-group v-model="mode" size="small">
           <el-radio-button value="private">私聊</el-radio-button>
@@ -62,17 +70,45 @@ import { useStore } from '~/store';
 import imgSeal from '~/assets/seal.png';
 import imgMe from '~/assets/me.jpg';
 import { Plus } from '@element-plus/icons-vue';
-import { getRecentMessage, postExec } from '~/api/dice';
+import {
+  getExecSplitOptions,
+  getRecentMessage,
+  postExec,
+  type ExecSplitOption,
+  type ExecSplitOptionKey,
+} from '~/api/dice';
 import { reloadDeck as postReloadDeck } from '~/api/deck';
 import { reloadHelpDoc } from '~/api/helpdoc';
 import { reloadJS } from '~/api/js';
 const store = useStore();
 
 const mode = ref<'private' | 'group'>('private');
+const fallbackSplitOptions: ExecSplitOption[] = [
+  { key: 'short', label: '短分段 300', messageSplitLen: 300 },
+  { key: 'qq', label: 'QQ 分段 2000', messageSplitLen: 2000 },
+  { key: 'unlimited', label: '无限', messageSplitLen: 0 },
+];
+const splitOptions = ref<ExecSplitOption[]>(fallbackSplitOptions);
+const splitKey = ref<ExecSplitOptionKey>('short');
+const selectedSplitLen = computed(
+  () =>
+    splitOptions.value.find(option => option.key === splitKey.value)?.messageSplitLen ??
+    fallbackSplitOptions[0].messageSplitLen,
+);
 
 let timerMsg: number;
 onBeforeMount(async () => {
   restaurants.value = loadAll();
+  try {
+    const data = await getExecSplitOptions();
+    if (data?.options?.length) {
+      splitOptions.value = data.options;
+      if (data.options.some(option => option.key === data.defaultKey)) {
+        splitKey.value = data.defaultKey;
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (e: any) {}
   timerMsg = setInterval(async () => {
     try {
       const msg = await getRecentMessage();
@@ -134,7 +170,7 @@ const doSend = async () => {
       mode: mode.value,
     });
     try {
-      await postExec(text, mode.value);
+      await postExec(text, mode.value, selectedSplitLen.value);
       // for (let i of ret) {
       //   store.talkLogs.push({
       //     content: i.message,

--- a/src/components/tool/PageTest.vue
+++ b/src/components/tool/PageTest.vue
@@ -3,7 +3,7 @@
     <div class="mb-3 flex flex-wrap items-center justify-end gap-3">
       <div class="flex items-center">
         <el-text class="mr-1.5">分段：</el-text>
-        <el-radio-group v-model="splitKey" size="small">
+        <el-radio-group v-model="splitKey" size="small" :disabled="!splitOptionsSupported">
           <el-radio-button v-for="option in splitOptions" :key="option.key" :value="option.key">
             {{ option.label }}
           </el-radio-button>
@@ -89,6 +89,7 @@ const fallbackSplitOptions: ExecSplitOption[] = [
   { key: 'unlimited', label: '无限', messageSplitLen: 0 },
 ];
 const splitOptions = ref<ExecSplitOption[]>(fallbackSplitOptions);
+const splitOptionsSupported = ref(true);
 const splitKey = ref<ExecSplitOptionKey>('short');
 const selectedSplitLen = computed(
   () =>
@@ -107,8 +108,11 @@ onBeforeMount(async () => {
         splitKey.value = data.defaultKey;
       }
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (e: any) {}
+    splitOptionsSupported.value = true;
+  } catch {
+    splitOptionsSupported.value = false;
+    ElMessage.warning('当前后端不支持测试分段设置');
+  }
   timerMsg = setInterval(async () => {
     try {
       const msg = await getRecentMessage();

--- a/src/components/tool/PageTest.vue
+++ b/src/components/tool/PageTest.vue
@@ -94,7 +94,8 @@ const splitKey = ref<ExecSplitOptionKey>('qq');
 const selectedSplitLen = computed(
   () =>
     splitOptions.value.find(option => option.key === splitKey.value)?.messageSplitLen ??
-    fallbackSplitOptions[1].messageSplitLen,
+    fallbackSplitOptions.find(option => option.key === 'qq')?.messageSplitLen ??
+    fallbackSplitOptions[0].messageSplitLen,
 );
 
 let timerMsg: number;


### PR DESCRIPTION
sealdice/sealdice-core#1694

<img width="573" height="462" alt="image" src="https://github.com/user-attachments/assets/9b549ddf-346d-440e-a03c-399562655c8d" />


## Summary by Sourcery

在指令测试页面中添加可配置的回复分段选项，并将其贯通接入到 exec API。

新功能：
- 在指令测试页面中引入回复分段模式选择器，提供 UI 控件和默认预设。
- 提供一个 API，用于从后端获取可用的 exec 回复分段选项以及默认键值。
- 允许 exec 请求在执行命令时可选地指定消息分段长度。

增强：
- 优雅处理不支持回复分段选项的后端，回退到本地默认设置并禁用选择器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable reply splitting options to the instruction test page and wire them through to the exec API.

New Features:
- Introduce reply splitting mode selection on the instruction test page with UI controls and default presets.
- Expose an API to fetch available exec reply split options and default key from the backend.
- Allow exec requests to optionally specify a message split length when executing commands.

Enhancements:
- Gracefully handle backends that do not support reply split options, falling back to local defaults and disabling the selector.

</details>