### PR TITLE
feat:官方机器人连接相关功能添加

### DIFF
--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -269,6 +269,7 @@ declare global {
   const useThrottleFn: typeof import('@vueuse/core')['useThrottleFn']
   const useThrottledRefHistory: typeof import('@vueuse/core')['useThrottledRefHistory']
   const useTimeAgo: typeof import('@vueuse/core')['useTimeAgo']
+  const useTimeAgoIntl: typeof import('@vueuse/core')['useTimeAgoIntl']
   const useTimeout: typeof import('@vueuse/core')['useTimeout']
   const useTimeoutFn: typeof import('@vueuse/core')['useTimeoutFn']
   const useTimeoutPoll: typeof import('@vueuse/core')['useTimeoutPoll']
@@ -584,6 +585,7 @@ declare module 'vue' {
     readonly useThrottleFn: UnwrapRef<typeof import('@vueuse/core')['useThrottleFn']>
     readonly useThrottledRefHistory: UnwrapRef<typeof import('@vueuse/core')['useThrottledRefHistory']>
     readonly useTimeAgo: UnwrapRef<typeof import('@vueuse/core')['useTimeAgo']>
+    readonly useTimeAgoIntl: UnwrapRef<typeof import('@vueuse/core')['useTimeAgoIntl']>
     readonly useTimeout: UnwrapRef<typeof import('@vueuse/core')['useTimeout']>
     readonly useTimeoutFn: UnwrapRef<typeof import('@vueuse/core')['useTimeoutFn']>
     readonly useTimeoutPoll: UnwrapRef<typeof import('@vueuse/core')['useTimeoutPoll']>

--- a/src/api/dice/index.ts
+++ b/src/api/dice/index.ts
@@ -103,7 +103,6 @@ export type DiceConfig = {
   ignoreUnaddressedBotCmd: boolean; // 忽略未定向给机器人的命令
   QQEnablePoke: boolean; // 是否启用QQ戳一戳功能
   officialQQFileSendBase64: boolean; // 是否以 Base64 发送文件
-  officialQQDisableSplit: boolean; // 是否禁用长消息分段
   officialQQUseMarkdown: boolean; // 是否使用 Markdown
   playerNameWrapEnable: boolean; // 是否启用玩家名包裹
   mailEnable: boolean; // 是否启用邮件功能

--- a/src/api/dice/index.ts
+++ b/src/api/dice/index.ts
@@ -102,6 +102,9 @@ export type DiceConfig = {
   textCmdTrustOnly: boolean; // 仅信任的文本命令
   ignoreUnaddressedBotCmd: boolean; // 忽略未定向给机器人的命令
   QQEnablePoke: boolean; // 是否启用QQ戳一戳功能
+  officialQQFileSendBase64: boolean; // 是否以 Base64 发送文件
+  officialQQDisableSplit: boolean; // 是否禁用长消息分段
+  officialQQUseMarkdown: boolean; // 是否使用 Markdown
   playerNameWrapEnable: boolean; // 是否启用玩家名包裹
   mailEnable: boolean; // 是否启用邮件功能
   mailFrom: string; // 邮件发件人

--- a/src/api/im_connections/index.ts
+++ b/src/api/im_connections/index.ts
@@ -143,15 +143,28 @@ export function postAddSlack(botToken: string, appToken: string) {
 }
 
 export function postAddOfficialQQ(
-  appID: number,
+  appID: string | number,
   appSecret: string,
   token: string,
   onlyQQGuild: boolean,
+  useWebhook: boolean,
+  webhookPath: string,
+  webhookPort: number,
+  webhookSecret: string,
 ) {
   return request<DiceConnection>(
     'post',
     'addOfficialQQ',
-    { appID, appSecret, token, onlyQQGuild },
+    {
+      appID: String(appID),
+      appSecret,
+      token,
+      onlyQQGuild,
+      useWebhook,
+      webhookPath,
+      webhookPort,
+      webhookSecret,
+    },
     'json',
     {
       timeout: 65000,
@@ -293,6 +306,10 @@ interface AdapterQQ {
   built_in_mode: string; // Milky
   signServerVer: string;
   signServerName: string;
+  useWebhook?: boolean;
+  webhookPath?: string;
+  webhookPort?: number;
+  webhookSecret?: string;
 }
 enum goCqHttpStateCode {
   Init = 0,

--- a/src/api/im_connections/index.ts
+++ b/src/api/im_connections/index.ts
@@ -150,7 +150,6 @@ export function postAddOfficialQQ(
   useWebhook: boolean,
   webhookPath: string,
   webhookPort: number,
-  webhookSecret: string,
 ) {
   return request<DiceConnection>(
     'post',
@@ -163,7 +162,6 @@ export function postAddOfficialQQ(
       useWebhook,
       webhookPath,
       webhookPort,
-      webhookSecret,
     },
     'json',
     {
@@ -299,7 +297,7 @@ interface AdapterQQ {
   redVersion: string;
   host: string;
   port: number;
-  appID: number;
+  appID: string | number;
   isReverse: boolean;
   reverseAddr: string;
   builtinMode: 'gocq' | 'lagrange' | 'lagrange-gocq';
@@ -309,7 +307,6 @@ interface AdapterQQ {
   useWebhook?: boolean;
   webhookPath?: string;
   webhookPort?: number;
-  webhookSecret?: string;
 }
 enum goCqHttpStateCode {
   Init = 0,

--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -283,11 +283,22 @@
 
           <template v-if="i.platform === 'QQ' && i.protocolType === 'official'">
             <el-form-item label="协议">
-              <div>[WIP] 官方 QQ Bot</div>
+              <div>官方 QQ Bot</div>
             </el-form-item>
             <el-form-item label="AppID">
               <div>{{ i.adapter?.appID }}</div>
             </el-form-item>
+            <el-form-item label="连接方式">
+              <div>{{ i.adapter?.useWebhook ? 'Webhook' : 'WebSocket' }}</div>
+            </el-form-item>
+            <template v-if="i.adapter?.useWebhook">
+              <el-form-item label="回调路径">
+                <div>{{ i.adapter?.webhookPath }}</div>
+              </el-form-item>
+              <el-form-item label="监听端口">
+                <div>{{ i.adapter?.webhookPort }}</div>
+              </el-form-item>
+            </template>
           </template>
 
           <template
@@ -1490,6 +1501,50 @@
           required>
           <el-switch v-model="form.onlyQQGuild" />
         </el-form-item>
+        <el-form-item
+          v-if="form.accountType === ImConnectionTypeOfficialQQ"
+          label="连接方式"
+          :label-width="formLabelWidth"
+          required>
+          <el-radio-group v-model="form.useWebhook">
+            <el-radio-button :value="false">WebSocket</el-radio-button>
+            <el-radio-button :value="true">Webhook</el-radio-button>
+          </el-radio-group>
+        </el-form-item>
+        <el-form-item
+          v-if="form.accountType === ImConnectionTypeOfficialQQ && form.useWebhook"
+          label="回调路径"
+          :label-width="formLabelWidth"
+          required>
+          <el-input
+            v-model="form.webhookPath"
+            placeholder="例如 /webhook/qq"
+            type="text"
+            autocomplete="off"></el-input>
+        </el-form-item>
+        <el-form-item
+          v-if="form.accountType === ImConnectionTypeOfficialQQ && form.useWebhook"
+          label="监听端口"
+          :label-width="formLabelWidth"
+          required>
+          <el-input-number
+            v-model="form.webhookPort"
+            :min="1"
+            :max="65535"
+            placeholder="例如 8099"
+            autocomplete="off"></el-input-number>
+        </el-form-item>
+        <el-form-item
+          v-if="form.accountType === ImConnectionTypeOfficialQQ && form.useWebhook"
+          label="校验密钥"
+          :label-width="formLabelWidth">
+          <el-input
+            v-model="form.webhookSecret"
+            placeholder="Webhook密钥（可选，不设置请留空）"
+            type="password"
+            show-password
+            autocomplete="off"></el-input>
+        </el-form-item>
 
         <el-form-item
           v-if="form.accountType === ImConnectionTypeOfficialQQ"
@@ -1952,7 +2007,13 @@
                   form.signServerName === '')) ||
               (form.accountType === ImConnectionTypeMilkySeparate &&
                 (form.wsGateway === '' || form.restGateway === '')) ||
-              (isInternalMilkyAccountType(form.accountType) && form.account === '')
+              (isInternalMilkyAccountType(form.accountType) && form.account === '') ||
+              (form.accountType === ImConnectionTypeOfficialQQ &&
+                (form.appID === undefined ||
+                  form.appID === '' ||
+                  form.token === '' ||
+                  form.appSecret === '' ||
+                  (form.useWebhook && (form.webhookPath === '' || form.webhookPort === undefined))))
             "
             @click="goStepTwo">
             下一步</el-button
@@ -2596,6 +2657,11 @@ const form = reactive({
   appID: undefined,
   appSecret: '',
   onlyQQGuild: true,
+
+  useWebhook: false,
+  webhookPath: '/webhook/qq',
+  webhookPort: 8099,
+  webhookSecret: '',
 
   useSignServer: false,
   signServerConfig: {

--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -1518,7 +1518,7 @@
           required>
           <el-input
             v-model="form.webhookPath"
-            placeholder="例如 /webhook/qq"
+            placeholder="例如 /webhook"
             type="text"
             autocomplete="off"></el-input>
         </el-form-item>
@@ -1533,17 +1533,6 @@
             :max="65535"
             placeholder="例如 8099"
             autocomplete="off"></el-input-number>
-        </el-form-item>
-        <el-form-item
-          v-if="form.accountType === ImConnectionTypeOfficialQQ && form.useWebhook"
-          label="校验密钥"
-          :label-width="formLabelWidth">
-          <el-input
-            v-model="form.webhookSecret"
-            placeholder="Webhook密钥（可选，不设置请留空）"
-            type="password"
-            show-password
-            autocomplete="off"></el-input>
         </el-form-item>
 
         <el-form-item
@@ -2656,10 +2645,10 @@ const form = reactive({
 
   appID: undefined,
   appSecret: '',
-  onlyQQGuild: true,
+  onlyQQGuild: false,
 
   useWebhook: false,
-  webhookPath: '/webhook/qq',
+  webhookPath: '/webhook',
   webhookPort: 8099,
   webhookSecret: '',
 

--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -283,7 +283,7 @@
 
           <template v-if="i.platform === 'QQ' && i.protocolType === 'official'">
             <el-form-item label="协议">
-              <div>官方 QQ Bot</div>
+              <div>[WIP] 官方 QQ Bot</div>
             </el-form-item>
             <el-form-item label="AppID">
               <div>{{ i.adapter?.appID }}</div>
@@ -2643,14 +2643,13 @@ const form = reactive({
   host: '',
   port: '',
 
-  appID: undefined,
+  appID: '' as string | number,
   appSecret: '',
   onlyQQGuild: false,
 
   useWebhook: false,
   webhookPath: '/webhook',
   webhookPort: 8099,
-  webhookSecret: '',
 
   useSignServer: false,
   signServerConfig: {

--- a/src/components/misc/PageMiscSettings.vue
+++ b/src/components/misc/PageMiscSettings.vue
@@ -229,6 +229,42 @@
     <el-form-item>
       <template #label>
         <div>
+          <span>QQ 官方机器人：以 Base64 发送文件</span>
+          <el-tooltip raw-content content="是否使用 Base64 发送本地/非公网图片或语音文件。">
+            <el-icon><question-filled /></el-icon>
+          </el-tooltip>
+        </div>
+      </template>
+      <el-checkbox v-model="config.officialQQFileSendBase64" label="开启" />
+    </el-form-item>
+
+    <el-form-item>
+      <template #label>
+        <div>
+          <span>QQ 官方机器人：禁用长消息分段</span>
+          <el-tooltip raw-content content="是否禁用长消息分段发送。">
+            <el-icon><question-filled /></el-icon>
+          </el-tooltip>
+        </div>
+      </template>
+      <el-checkbox v-model="config.officialQQDisableSplit" label="开启" />
+    </el-form-item>
+
+    <el-form-item>
+      <template #label>
+        <div>
+          <span>QQ 官方机器人：使用 Markdown</span>
+          <el-tooltip raw-content content="是否自动把发送的所有群聊和频道消息全转为 Markdown 类型消息。">
+            <el-icon><question-filled /></el-icon>
+          </el-tooltip>
+        </div>
+      </template>
+      <el-checkbox v-model="config.officialQQUseMarkdown" label="开启" />
+    </el-form-item>
+
+    <el-form-item>
+      <template #label>
+        <div>
           <span>限制.text 指令</span>
           <el-tooltip
             raw-content

--- a/src/components/misc/PageMiscSettings.vue
+++ b/src/components/misc/PageMiscSettings.vue
@@ -230,7 +230,9 @@
       <template #label>
         <div>
           <span>以 Base64 发送文件</span>
-          <el-tooltip raw-content content="是否使用 Base64 发送本地/非公网图片或语音文件，仅对QQ 官方机器人有效。">
+          <el-tooltip
+            raw-content
+            content="是否使用 Base64 发送本地/非公网图片或语音文件，仅对QQ 官方机器人有效。">
             <el-icon><question-filled /></el-icon>
           </el-tooltip>
         </div>
@@ -238,12 +240,13 @@
       <el-checkbox v-model="config.officialQQFileSendBase64" label="开启" />
     </el-form-item>
 
-
     <el-form-item>
       <template #label>
         <div>
           <span>使用 Markdown</span>
-          <el-tooltip raw-content content="是否自动把发送的所有群聊和频道消息全转为 Markdown 类型消息，仅对QQ 官方机器人有效。">
+          <el-tooltip
+            raw-content
+            content="是否自动把发送的所有群聊和频道消息全转为 Markdown 类型消息，仅对QQ 官方机器人有效。">
             <el-icon><question-filled /></el-icon>
           </el-tooltip>
         </div>

--- a/src/components/misc/PageMiscSettings.vue
+++ b/src/components/misc/PageMiscSettings.vue
@@ -229,8 +229,8 @@
     <el-form-item>
       <template #label>
         <div>
-          <span>QQ 官方机器人：以 Base64 发送文件</span>
-          <el-tooltip raw-content content="是否使用 Base64 发送本地/非公网图片或语音文件。">
+          <span>以 Base64 发送文件</span>
+          <el-tooltip raw-content content="是否使用 Base64 发送本地/非公网图片或语音文件，仅对QQ 官方机器人有效。">
             <el-icon><question-filled /></el-icon>
           </el-tooltip>
         </div>
@@ -238,23 +238,12 @@
       <el-checkbox v-model="config.officialQQFileSendBase64" label="开启" />
     </el-form-item>
 
-    <el-form-item>
-      <template #label>
-        <div>
-          <span>QQ 官方机器人：禁用长消息分段</span>
-          <el-tooltip raw-content content="是否禁用长消息分段发送。">
-            <el-icon><question-filled /></el-icon>
-          </el-tooltip>
-        </div>
-      </template>
-      <el-checkbox v-model="config.officialQQDisableSplit" label="开启" />
-    </el-form-item>
 
     <el-form-item>
       <template #label>
         <div>
-          <span>QQ 官方机器人：使用 Markdown</span>
-          <el-tooltip raw-content content="是否自动把发送的所有群聊和频道消息全转为 Markdown 类型消息。">
+          <span>使用 Markdown</span>
+          <el-tooltip raw-content content="是否自动把发送的所有群聊和频道消息全转为 Markdown 类型消息，仅对QQ 官方机器人有效。">
             <el-icon><question-filled /></el-icon>
           </el-tooltip>
         </div>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -95,6 +95,10 @@ export interface AdapterQQ {
   built_in_mode: string; // Milky 的字段，跟 ob 不太一样
   signServerVer: string;
   signServerName: string;
+  useWebhook?: boolean;
+  webhookPath?: string;
+  webhookPort?: number;
+  webhookSecret?: string;
 }
 
 interface TalkLogItem {
@@ -323,6 +327,10 @@ export const useStore = defineStore('main', {
         wsGateway,
         restGateway,
         builtInMode,
+        useWebhook,
+        webhookPath,
+        webhookPort,
+        webhookSecret,
       } = form;
 
       let info = null;
@@ -378,7 +386,16 @@ export const useStore = defineStore('main', {
           info = await postAddSlack(botToken, appToken);
           break;
         case ImConnectionTypeOfficialQQ:
-          info = await postAddOfficialQQ(Number(appID), appSecret, token, onlyQQGuild);
+          info = await postAddOfficialQQ(
+            appID as any,
+            appSecret,
+            token,
+            onlyQQGuild,
+            useWebhook,
+            webhookPath,
+            webhookPort,
+            webhookSecret,
+          );
           break;
         case ImConnectionTypeOnebotReverse:
           info = await postAddOnebot11ReverseWs(account, reverseAddr?.trim());

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -88,7 +88,7 @@ export interface AdapterQQ {
   redVersion: string;
   host: string;
   port: number;
-  appID: number;
+  appID: string | number;
   isReverse: boolean;
   reverseAddr: string;
   builtinMode: 'gocq' | 'lagrange' | 'lagrange-gocq';
@@ -98,7 +98,6 @@ export interface AdapterQQ {
   useWebhook?: boolean;
   webhookPath?: string;
   webhookPort?: number;
-  webhookSecret?: string;
 }
 
 interface TalkLogItem {
@@ -330,7 +329,6 @@ export const useStore = defineStore('main', {
         useWebhook,
         webhookPath,
         webhookPort,
-        webhookSecret,
       } = form;
 
       let info = null;
@@ -387,14 +385,13 @@ export const useStore = defineStore('main', {
           break;
         case ImConnectionTypeOfficialQQ:
           info = await postAddOfficialQQ(
-            appID as any,
+            appID,
             appSecret,
             token,
             onlyQQGuild,
             useWebhook,
             webhookPath,
             webhookPort,
-            webhookSecret,
           );
           break;
         case ImConnectionTypeOnebotReverse:


### PR DESCRIPTION
[后端](https://github.com/sealdice/sealdice-core/pull/1703)
<img width="960" height="895" alt="image" src="https://github.com/user-attachments/assets/90f7005d-f873-4368-89bc-0c9561e4af4c" />
<img width="618" height="362" alt="image" src="https://github.com/user-attachments/assets/ce649ec1-e113-4a99-831c-c554d1553fee" />

## Sourcery 总结

为官方 QQ 机器人集成添加可配置的连接选项和行为。

新增功能：
- 在连接信息视图中显示官方 QQ 机器人适配器的连接类型和 Webhook 详细信息。
- 在添加官方 QQ 连接时，允许配置 WebSocket 与 Webhook 模式、回调路径以及监听端口，并在继续前进行校验。
- 引入全局设置，以 Base64 方式发送文件，并强制所有群组/频道消息在官方 QQ 机器人中使用 Markdown 格式。

增强内容：
- 扩展官方 QQ 添加连接的 API 和存储逻辑，以支持与 Webhook 相关的参数，并将 AppID 视为兼容字符串的类型。
- 调整官方 QQ 连接表单的默认值，默认关闭“仅限频道（guild-only）”，并预填 Webhook 配置字段。
- 更新 QQ 适配器的类型定义，加入可选的 Webhook 配置字段。
- 在自动导入的类型定义中暴露 `useTimeAgoIntl` 以供 Vue 使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable connection options and behavior for the official QQ bot integration.

New Features:
- Display official QQ bot adapter connection type and webhook details in the connection info view.
- Allow configuring WebSocket vs Webhook mode, callback path, and listening port when adding an official QQ connection, including validation before proceeding.
- Introduce global settings to send files as Base64 and to force all group/channel messages to use Markdown for the official QQ bot.

Enhancements:
- Extend official QQ add-connection API and store wiring to support webhook-related parameters and treat AppID as string-compatible.
- Adjust default official QQ connection form values to disable guild-only by default and prefill webhook configuration fields.
- Update QQ adapter typings to include optional webhook configuration fields.
- Expose useTimeAgoIntl in auto-import typings for Vue use.

</details>