### PR TITLE
chore: 添加 V1.6 版本鸣谢名单

### DIFF
--- a/src/components/PageAbout.vue
+++ b/src/components/PageAbout.vue
@@ -52,76 +52,19 @@
 
     <div style="margin-top: 2rem" class="subtitle">V1.6 版本</div>
     <div class="developers">
-      <el-link :underline="false" href="https://github.com/Szzrain" target="_blank"
-        ><el-avatar
+      <el-link
+        v-for="contributor in v16Contributors"
+        :key="contributor.github"
+        :underline="false"
+        :href="`https://github.com/${contributor.github}`"
+        target="_blank"
+        rel="noopener noreferrer">
+        <el-avatar
           shape="circle"
           :size="50"
-          :src="urlBase + '/sd-api/utils/ga/Szzrain'" />Szzrain</el-link
-      >
-      <el-link :underline="false" href="https://github.com/fy0" target="_blank"
-        ><el-avatar
-          shape="circle"
-          :size="50"
-          :src="urlBase + '/sd-api/utils/ga/fy0'" />木落</el-link
-      >
-      <el-link :underline="false" href="https://github.com/MX-fox" target="_blank"
-        ><el-avatar
-          shape="circle"
-          :size="50"
-          :src="urlBase + '/sd-api/utils/ga/MX-fox'" />暮星</el-link
-      >
-      <el-link :underline="false" href="https://github.com/kenichiLyon" target="_blank"
-        ><el-avatar
-          shape="circle"
-          :size="50"
-          src="https://d1.sealdice.com/images/kenichiLyon.jpg" />山本健一</el-link
-      >
-      <el-link :underline="false" href="https://github.com/PaienNate" target="_blank"
-        ><el-avatar
-          shape="circle"
-          :size="50"
-          :src="urlBase + '/sd-api/utils/ga/PaienNate'" />PaienNate</el-link
-      >
-      <el-link :underline="false" href="https://github.com/baiyu-yu" target="_blank"
-        ><el-avatar
-          shape="circle"
-          :size="50"
-          :src="urlBase + '/sd-api/utils/ga/baiyu-yu'" />白鱼</el-link
-      >
-      <el-link :underline="false" href="https://github.com/lyjjl" target="_blank"
-        ><el-avatar
-          shape="circle"
-          :size="50"
-          :src="urlBase + '/sd-api/utils/ga/lyjjl'" />SomeOne</el-link
-      >
-      <el-link :underline="false" href="https://github.com/kagangtuya-star" target="_blank"
-        ><el-avatar
-          shape="circle"
-          :size="50"
-          :src="urlBase + '/sd-api/utils/ga/kagangtuya-star'" />SilverDragon</el-link
-      >
-      <el-link :underline="false" href="https://github.com/oissevalt" target="_blank"
-        ><el-avatar
-          shape="circle"
-          :size="50"
-          :src="urlBase + '/sd-api/utils/ga/oissevalt'" />檀轶步棋</el-link
-      >
-      <el-link :underline="false" href="https://github.com/BQxiaojiao" target="_blank"
-        ><el-avatar
-          shape="circle"
-          :size="50"
-          :src="urlBase + '/sd-api/utils/ga/BQxiaojiao'" />BQxiaojiao</el-link
-      >
-      <el-link :underline="false" href="https://github.com/Dontplay0112" target="_blank"
-        ><el-avatar
-          shape="circle"
-          :size="50"
-          :src="urlBase + '/sd-api/utils/ga/Dontplay0112'" />Dontplay (UI)</el-link
-      >
-      <el-link :underline="false" href="https://github.com/ShiaNyaa" target="_blank"
-        ><el-avatar shape="circle" :size="50" :src="urlBase + '/sd-api/utils/ga/ShiaNyaa'" />希亚
-        (UI)</el-link
-      >
+          :src="`${urlBase}/sd-api/utils/ga/${contributor.github}`" />
+        {{ contributor.name }}
+      </el-link>
     </div>
 
     <div style="margin-top: 2rem" class="subtitle">V1.5 版本</div>
@@ -717,6 +660,21 @@ import imgHaibao from '~/assets/haibao1.png';
 import { urlBase } from '~/backend';
 
 const store = useStore();
+
+const v16Contributors = [
+  { github: 'Szzrain', name: 'Szzrain' },
+  { github: 'fy0', name: '木落' },
+  { github: 'MX-fox', name: '暮星' },
+  { github: 'kenichiLyon', name: '山本健一' },
+  { github: 'PaienNate', name: 'PaienNate' },
+  { github: 'baiyu-yu', name: '白鱼' },
+  { github: 'lyjjl', name: 'SomeOne' },
+  { github: 'kagangtuya-star', name: 'SilverDragon' },
+  { github: 'oissevalt', name: '檀轶步棋' },
+  { github: 'BQxiaojiao', name: 'BQxiaojiao' },
+  { github: 'Dontplay0112', name: 'Dontplay (UI)' },
+  { github: 'ShiaNyaa', name: '希亚 (UI)' },
+] as const;
 
 onBeforeMount(async () => {
   await store.logFetchAndClear();

--- a/src/components/PageAbout.vue
+++ b/src/components/PageAbout.vue
@@ -55,6 +55,9 @@
       <el-link
         v-for="contributor in v16Contributors"
         :key="contributor.github"
+        :class="{
+          'developer-muted': contributor.github === 'PaienNate' && contributor.name !== 'PaienNate',
+        }"
         :underline="false"
         :href="`https://github.com/${contributor.github}`"
         target="_blank"
@@ -665,12 +668,19 @@ const wesleyYoungNames = ['Wesley-Young', '白圣女', '盐巴猫'] as const;
 const wesleyYoungName =
   wesleyYoungNames[Math.floor(Math.random() * wesleyYoungNames.length)] ?? wesleyYoungNames[0];
 
+const paienNateSpecialNames = ['*走丢了', '*这个人上班去了'] as const;
+const paienNateName =
+  Math.random() < 0.35
+    ? (paienNateSpecialNames[Math.floor(Math.random() * paienNateSpecialNames.length)] ??
+      paienNateSpecialNames[0])
+    : 'PaienNate';
+
 const v16Contributors = [
   { github: 'Szzrain', name: 'Szzrain' },
   { github: 'fy0', name: '木落' },
   { github: 'MX-fox', name: '暮星' },
   { github: 'kenichiLyon', name: '山本健一' },
-  { github: 'PaienNate', name: 'PaienNate' },
+  { github: 'PaienNate', name: paienNateName },
   { github: 'baiyu-yu', name: '白鱼' },
   { github: 'lyjjl', name: 'SomeOne' },
   { github: 'kagangtuya-star', name: 'SilverDragon' },
@@ -678,6 +688,7 @@ const v16Contributors = [
   { github: 'BQxiaojiao', name: 'BQxiaojiao' },
   { github: 'kainordherd', name: 'Kai' },
   { github: 'Wesley-Young', name: wesleyYoungName },
+  { github: 'Lirvis', name: '莉尔维斯(Lirvis) (sealrepo)' },
   { github: 'Dontplay0112', name: 'Dontplay (UI)' },
   { github: 'ShiaNyaa', name: '希亚 (UI)' },
 ] as const;
@@ -723,6 +734,16 @@ onBeforeUnmount(() => {
 
 .developers .el-avatar {
   margin-right: 0.5rem;
+}
+
+.developers .developer-muted {
+  --el-link-text-color: var(--el-text-color-secondary);
+  --el-link-hover-text-color: var(--el-text-color-secondary);
+}
+
+.developers .developer-muted .el-avatar {
+  filter: grayscale(1);
+  opacity: 0.6;
 }
 
 .developers > * {

--- a/src/components/PageAbout.vue
+++ b/src/components/PageAbout.vue
@@ -672,6 +672,8 @@ const v16Contributors = [
   { github: 'kagangtuya-star', name: 'SilverDragon' },
   { github: 'oissevalt', name: '檀轶步棋' },
   { github: 'BQxiaojiao', name: 'BQxiaojiao' },
+  { github: 'kainordherd', name: 'Kai' },
+  { github: 'Wesley-Young', name: 'Wesley-Young' },
   { github: 'Dontplay0112', name: 'Dontplay (UI)' },
   { github: 'ShiaNyaa', name: '希亚 (UI)' },
 ] as const;

--- a/src/components/PageAbout.vue
+++ b/src/components/PageAbout.vue
@@ -50,6 +50,80 @@
     <div></div>
     <div class="subtitle">社区协力</div>
 
+    <div style="margin-top: 2rem" class="subtitle">V1.6 版本</div>
+    <div class="developers">
+      <el-link :underline="false" href="https://github.com/Szzrain" target="_blank"
+        ><el-avatar
+          shape="circle"
+          :size="50"
+          :src="urlBase + '/sd-api/utils/ga/Szzrain'" />Szzrain</el-link
+      >
+      <el-link :underline="false" href="https://github.com/fy0" target="_blank"
+        ><el-avatar
+          shape="circle"
+          :size="50"
+          :src="urlBase + '/sd-api/utils/ga/fy0'" />木落</el-link
+      >
+      <el-link :underline="false" href="https://github.com/MX-fox" target="_blank"
+        ><el-avatar
+          shape="circle"
+          :size="50"
+          :src="urlBase + '/sd-api/utils/ga/MX-fox'" />暮星</el-link
+      >
+      <el-link :underline="false" href="https://github.com/kenichiLyon" target="_blank"
+        ><el-avatar
+          shape="circle"
+          :size="50"
+          src="https://d1.sealdice.com/images/kenichiLyon.jpg" />山本健一</el-link
+      >
+      <el-link :underline="false" href="https://github.com/PaienNate" target="_blank"
+        ><el-avatar
+          shape="circle"
+          :size="50"
+          :src="urlBase + '/sd-api/utils/ga/PaienNate'" />PaienNate</el-link
+      >
+      <el-link :underline="false" href="https://github.com/baiyu-yu" target="_blank"
+        ><el-avatar
+          shape="circle"
+          :size="50"
+          :src="urlBase + '/sd-api/utils/ga/baiyu-yu'" />白鱼</el-link
+      >
+      <el-link :underline="false" href="https://github.com/lyjjl" target="_blank"
+        ><el-avatar
+          shape="circle"
+          :size="50"
+          :src="urlBase + '/sd-api/utils/ga/lyjjl'" />SomeOne</el-link
+      >
+      <el-link :underline="false" href="https://github.com/kagangtuya-star" target="_blank"
+        ><el-avatar
+          shape="circle"
+          :size="50"
+          :src="urlBase + '/sd-api/utils/ga/kagangtuya-star'" />SilverDragon</el-link
+      >
+      <el-link :underline="false" href="https://github.com/oissevalt" target="_blank"
+        ><el-avatar
+          shape="circle"
+          :size="50"
+          :src="urlBase + '/sd-api/utils/ga/oissevalt'" />檀轶步棋</el-link
+      >
+      <el-link :underline="false" href="https://github.com/BQxiaojiao" target="_blank"
+        ><el-avatar
+          shape="circle"
+          :size="50"
+          :src="urlBase + '/sd-api/utils/ga/BQxiaojiao'" />BQxiaojiao</el-link
+      >
+      <el-link :underline="false" href="https://github.com/Dontplay0112" target="_blank"
+        ><el-avatar
+          shape="circle"
+          :size="50"
+          :src="urlBase + '/sd-api/utils/ga/Dontplay0112'" />Dontplay (UI)</el-link
+      >
+      <el-link :underline="false" href="https://github.com/ShiaNyaa" target="_blank"
+        ><el-avatar shape="circle" :size="50" :src="urlBase + '/sd-api/utils/ga/ShiaNyaa'" />希亚
+        (UI)</el-link
+      >
+    </div>
+
     <div style="margin-top: 2rem" class="subtitle">V1.5 版本</div>
     <div class="developers">
       <el-link :underline="false" href="https://github.com/fy0" target="_blank"

--- a/src/components/PageAbout.vue
+++ b/src/components/PageAbout.vue
@@ -661,6 +661,10 @@ import { urlBase } from '~/backend';
 
 const store = useStore();
 
+const wesleyYoungNames = ['Wesley-Young', '白圣女', '盐巴猫'] as const;
+const wesleyYoungName =
+  wesleyYoungNames[Math.floor(Math.random() * wesleyYoungNames.length)] ?? wesleyYoungNames[0];
+
 const v16Contributors = [
   { github: 'Szzrain', name: 'Szzrain' },
   { github: 'fy0', name: '木落' },
@@ -673,7 +677,7 @@ const v16Contributors = [
   { github: 'oissevalt', name: '檀轶步棋' },
   { github: 'BQxiaojiao', name: 'BQxiaojiao' },
   { github: 'kainordherd', name: 'Kai' },
-  { github: 'Wesley-Young', name: 'Wesley-Young' },
+  { github: 'Wesley-Young', name: wesleyYoungName },
   { github: 'Dontplay0112', name: 'Dontplay (UI)' },
   { github: 'ShiaNyaa', name: '希亚 (UI)' },
 ] as const;

--- a/src/components/PageHome.vue
+++ b/src/components/PageHome.vue
@@ -38,34 +38,37 @@
       >
     </div>
 
-    <div class="flex items-center flex-wrap gap-1" @click="refreshNetworkHealth">
+    <div class="flex items-center flex-wrap gap-1">
       <el-tooltip raw-content content="点击重新进行检测">
-        <span>网络质量：</span>
+        <button class="network-health-trigger" type="button" @click="refreshNetworkHealth">
+          <span>网络质量：</span>
+
+          <el-text type="primary" v-if="networkHealth.timestamp === 0">检测中…… 🤔</el-text>
+          <el-text
+            type="success"
+            v-else-if="
+              networkHealth.total !== 0 && networkHealth.total === networkHealth.ok?.length
+            "
+            >优 😄</el-text
+          >
+          <el-text
+            type="primary"
+            v-else-if="networkHealth.ok?.includes('sign') && networkHealth.ok?.includes('seal')"
+            >一般 😐️</el-text
+          >
+          <el-text
+            type="danger"
+            v-else-if="networkHealth.total !== 0 && (networkHealth.ok ?? []).length === 0"
+            >网络中断 😱</el-text
+          >
+          <el-text v-else type="warning">差 ☹️</el-text>
+        </button>
       </el-tooltip>
 
-      <el-text type="primary" v-if="networkHealth.timestamp === 0">检测中…… 🤔</el-text>
-      <el-text
-        type="success"
-        v-else-if="networkHealth.total !== 0 && networkHealth.total === networkHealth.ok?.length"
-        >优 😄</el-text
+      <el-text v-if="isNetworkHealthPoor" class="ml-3" type="warning" size="small"
+        >这意味着你可能无法正常使用内置客户端/Lagrange 连接 QQ
+        平台，有时会出现消息无法正常发送的现象。</el-text
       >
-      <el-text
-        type="primary"
-        v-else-if="networkHealth.ok?.includes('sign') && networkHealth.ok?.includes('seal')"
-        >一般 😐️</el-text
-      >
-      <el-text
-        type="danger"
-        v-else-if="networkHealth.total !== 0 && (networkHealth.ok ?? []).length === 0"
-        >网络中断 😱</el-text
-      >
-      <template v-else>
-        <el-text type="warning" class="mr-4">差 ☹️</el-text>
-        <el-text type="warning" size="small"
-          >这意味着你可能无法正常使用内置客户端/Lagrange 连接 QQ
-          平台，有时会出现消息无法正常发送的现象。</el-text
-        >
-      </template>
 
       <el-tooltip v-if="networkHealth.timestamp !== 0">
         <template #content>
@@ -312,6 +315,16 @@ const networkHealth = ref({
   timestamp: number;
 });
 
+const isNetworkHealthPoor = computed(() => {
+  const { timestamp, total, ok } = networkHealth.value;
+  return (
+    timestamp !== 0 &&
+    !(total !== 0 && total === ok.length) &&
+    !(ok.includes('sign') && ok.includes('seal')) &&
+    !(total !== 0 && ok.length === 0)
+  );
+});
+
 let timerId: number;
 let checkTimerId: number;
 
@@ -437,6 +450,17 @@ onBeforeUnmount(() => {
   :deep(.el-divider__text) {
     background: #f3f4f6;
   }
+}
+
+.network-health-trigger {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
 }
 </style>
 


### PR DESCRIPTION
## 变更

- 在“关于”页新增 V1.6 版本鸣谢名单
- 根据 sealdice-core 从 v1.5.0 到当前 master，以及 sealdice-ui 同期主分支提交记录整理
- 收录 12 位人类提交者，并标注仅参与 UI 项目的贡献者

## 验证

- pnpm exec prettier --check src/components/PageAbout.vue
- pnpm run check

## Summary by Sourcery

新功能：
- 在“关于”页面中新增 V1.6 版本致谢部分，列出贡献者的头像和个人资料链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce a V1.6 version acknowledgements section on the About page listing contributors with avatars and profile links.

</details>