### PR TITLE
feat(official-qq): QQ 官方机器人支持扫码登陆

### DIFF
--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -313,7 +313,7 @@ declare global {
 // for type re-export
 declare global {
   // @ts-ignore
-  export type { Component, ComponentPublicInstance, ComputedRef, DirectiveBinding, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, MaybeRef, MaybeRefOrGetter, VNode, WritableComputedRef } from 'vue'
+  export type { Component, Slot, Slots, ComponentPublicInstance, ComputedRef, DirectiveBinding, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, MaybeRef, MaybeRefOrGetter, VNode, WritableComputedRef } from 'vue'
   import('vue')
 }
 

--- a/components.d.ts
+++ b/components.d.ts
@@ -112,6 +112,7 @@ declare module 'vue' {
     PageMiscDicePublic: typeof import('./src/components/misc/PageMiscDicePublic.vue')['default']
     PageMiscGroup: typeof import('./src/components/misc/PageMiscGroup.vue')['default']
     PageMiscSettings: typeof import('./src/components/misc/PageMiscSettings.vue')['default']
+    PagePackage: typeof import('./src/components/mod/PagePackage.vue')['default']
     PageProfile: typeof import('./src/components/tool/PageProfile.vue')['default']
     PageResource: typeof import('./src/components/tool/PageResource.vue')['default']
     PageStory: typeof import('./src/components/mod/PageStory.vue')['default']

--- a/package.json
+++ b/package.json
@@ -75,9 +75,5 @@
     "vite": "^7.3.2",
     "vue-eslint-parser": "^10.2.0",
     "vue-tsc": "^3.0.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"],
-    "ignoredBuiltDependencies": ["core-js", "vue-demi"]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss: 8.5.6
+
 importers:
 
   .:
@@ -151,7 +154,7 @@ importers:
         specifier: ^8.0.4
         version: 8.0.4
       postcss:
-        specifier: ^8.5.6
+        specifier: 8.5.6
         version: 8.5.6
       postcss-nested:
         specifier: ^7.0.2
@@ -1520,7 +1523,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.6
 
   axios-retry@4.5.0:
     resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
@@ -2367,19 +2370,19 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: ^8.0.0
+      postcss: 8.5.6
 
   postcss-js@4.0.1:
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: ^8.4.21
+      postcss: 8.5.6
 
   postcss-load-config@4.0.2:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
-      postcss: '>=8.0.9'
+      postcss: 8.5.6
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       postcss:
@@ -2391,13 +2394,13 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: 8.5.6
 
   postcss-nested@7.0.2:
     resolution: {integrity: sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: 8.5.6
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ allowBuilds:
   esbuild: true
   core-js: false
   vue-demi: false
+overrides:
+  postcss: 8.5.6

--- a/src/api/im_connections/index.ts
+++ b/src/api/im_connections/index.ts
@@ -145,7 +145,6 @@ export function postAddSlack(botToken: string, appToken: string) {
 export function postAddOfficialQQ(
   appID: string | number,
   appSecret: string,
-  token: string,
   onlyQQGuild: boolean,
   useWebhook: boolean,
   webhookPath: string,
@@ -157,7 +156,6 @@ export function postAddOfficialQQ(
     {
       appID: String(appID),
       appSecret,
-      token,
       onlyQQGuild,
       useWebhook,
       webhookPath,
@@ -219,7 +217,9 @@ export function postConnectionDel(id: string) {
 }
 
 export function postConnectionQrcode(id: string) {
-  return request<{ img: string }>('post', 'qrcode', { id });
+  // 二维码就绪时返回 { img: base64DataUrl }，其他状态下不包含 img 字段
+  // 支持 gocq / walle-q / milky / official 协议
+  return request<{ img?: string }>('post', 'qrcode', { id });
 }
 
 export function postSmsCodeSet(id: string, code: string) {
@@ -307,6 +307,14 @@ interface AdapterQQ {
   useWebhook?: boolean;
   webhookPath?: string;
   webhookPort?: number;
+  qrLoginState?: OfficialQQLoginState;
+}
+enum OfficialQQLoginState {
+  Init = 0,
+  QRWaitingForScan = 1,
+  QRScanned = 2,
+  Connecting = 3,
+  Failed = 4,
 }
 enum goCqHttpStateCode {
   Init = 0,

--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -38,7 +38,10 @@
 
         <div
           v-if="
-            i.adapter?.loginState === goCqHttpStateCode.InLoginQrCode && store.curDice.qrcodes[i.id]
+            (i.adapter?.loginState === goCqHttpStateCode.InLoginQrCode ||
+              (i.protocolType === 'official' &&
+                i.adapter?.qrLoginState === OfficialQQLoginState.QRWaitingForScan)) &&
+            store.curDice.qrcodes[i.id]
           "
           style="position: absolute; width: 17rem; height: 14rem; background: #fff; z-index: 1">
           <div style="margin-left: 2rem">需要同账号的手机 QQ 扫码登录 (限 2 分钟内完成):</div>
@@ -1468,6 +1471,18 @@
 
         <el-form-item
           v-if="form.accountType === ImConnectionTypeOfficialQQ"
+          label="登录方式"
+          :label-width="formLabelWidth"
+          required>
+          <el-radio-group v-model="form.officialQQLoginMode">
+            <el-radio-button value="manual">手动填写</el-radio-button>
+            <el-radio-button value="qrcode">扫码登录</el-radio-button>
+          </el-radio-group>
+        </el-form-item>
+        <el-form-item
+          v-if="
+            form.accountType === ImConnectionTypeOfficialQQ && form.officialQQLoginMode === 'manual'
+          "
           label="机器人ID"
           :label-width="formLabelWidth"
           required>
@@ -1478,18 +1493,9 @@
             type="number"></el-input>
         </el-form-item>
         <el-form-item
-          v-if="form.accountType === ImConnectionTypeOfficialQQ"
-          label="机器人令牌"
-          :label-width="formLabelWidth"
-          required>
-          <el-input
-            v-model="form.token"
-            placeholder="填写在开放平台获取的Token"
-            type="text"
-            autocomplete="off"></el-input>
-        </el-form-item>
-        <el-form-item
-          v-if="form.accountType === ImConnectionTypeOfficialQQ"
+          v-if="
+            form.accountType === ImConnectionTypeOfficialQQ && form.officialQQLoginMode === 'manual'
+          "
           label="机器人密钥"
           :label-width="formLabelWidth"
           required>
@@ -1501,20 +1507,10 @@
         </el-form-item>
         <el-form-item
           v-if="form.accountType === ImConnectionTypeOfficialQQ"
-          label="只在频道使用"
+          label="Webhook"
           :label-width="formLabelWidth"
           required>
-          <el-switch v-model="form.onlyQQGuild" />
-        </el-form-item>
-        <el-form-item
-          v-if="form.accountType === ImConnectionTypeOfficialQQ"
-          label="连接方式"
-          :label-width="formLabelWidth"
-          required>
-          <el-radio-group v-model="form.useWebhook">
-            <el-radio-button :value="false">WebSocket</el-radio-button>
-            <el-radio-button :value="true">Webhook</el-radio-button>
-          </el-radio-group>
+          <el-switch v-model="form.useWebhook" />
         </el-form-item>
         <el-form-item
           v-if="form.accountType === ImConnectionTypeOfficialQQ && form.useWebhook"
@@ -1544,14 +1540,25 @@
           v-if="form.accountType === ImConnectionTypeOfficialQQ"
           :label-width="formLabelWidth">
           <small>
-            <div>提示：进入腾讯开放平台创建一个机器人</div>
-            <div>
-              <a href="https://q.qq.com/#/app/bot" target="_blank" rel="noopener noreferrer"
-                >https://q.qq.com/#/app/bot</a
-              >
-            </div>
-            <div>创建之后进入机器人管理后台，切换到「开发 - 开发设置」页</div>
-            <div>把机器人的相关信息复制并粘贴进来</div>
+            <template v-if="form.officialQQLoginMode === 'manual'">
+              <div>
+                进入腾讯
+                <a href="https://q.qq.com/#/app/bot" target="_blank" rel="noopener noreferrer"
+                  >开放平台</a
+                >
+                创建一个机器人之后进入机器人管理后台，切换到「开发 - 开发设置」页
+              </div>
+              <div>把机器人的 AppID 与 AppSecret 复制并粘贴进来</div>
+            </template>
+            <template v-else>
+              <div>
+                进入腾讯
+                <a href="https://q.qq.com/#/app/bot" target="_blank" rel="noopener noreferrer"
+                  >开放平台</a
+                >
+                创建一个机器人，点击"下一步"生成二维码，使用手机 QQ 扫描完成绑定
+              </div>
+            </template>
           </small>
         </el-form-item>
 
@@ -1889,7 +1896,10 @@
           </div>
           <div
             v-else-if="
-              index === 2 && curConn.adapter?.loginState === goCqHttpStateCode.InLoginQrCode
+              index === 2 &&
+              (curConn.adapter?.loginState === goCqHttpStateCode.InLoginQrCode ||
+                (curConn.protocolType === 'official' &&
+                  curConn.adapter?.qrLoginState === OfficialQQLoginState.QRWaitingForScan))
             ">
             <div>登录需要扫码验证，请使用登录此账号的手机 QQ 扫描二维码以继续登录：</div>
             <img
@@ -2046,11 +2056,12 @@
                 (form.wsGateway === '' || form.restGateway === '')) ||
               (isInternalMilkyAccountType(form.accountType) && form.account === '') ||
               (form.accountType === ImConnectionTypeOfficialQQ &&
-                (form.appID === undefined ||
-                  form.appID === '' ||
-                  form.token === '' ||
-                  form.appSecret === '' ||
-                  (form.useWebhook && (form.webhookPath === '' || form.webhookPort === undefined))))
+                (form.officialQQLoginMode === 'manual'
+                  ? form.appID === undefined || form.appID === '' || form.appSecret === ''
+                  : false)) ||
+              (form.accountType === ImConnectionTypeOfficialQQ &&
+                form.useWebhook &&
+                (form.webhookPath === '' || form.webhookPort === undefined))
             "
             @click="goStepTwo">
             下一步</el-button
@@ -2110,6 +2121,7 @@ import { computed, reactive } from 'vue';
 import {
   useStore,
   goCqHttpStateCode,
+  OfficialQQLoginState,
   ImConnectionTypeGocqLegacy,
   ImConnectionTypeDiscord,
   ImConnectionTypeKook,
@@ -2409,6 +2421,7 @@ const formClose = async () => {
   dialogFormVisible.value = false;
   form.step = 1;
   form.isEnd = false;
+  form.officialQQLoginMode = 'manual';
 };
 
 const setEnable = async (i: DiceConnection, val: boolean) => {
@@ -2707,7 +2720,7 @@ const form = reactive({
 
   appID: '' as string | number,
   appSecret: '',
-  onlyQQGuild: false,
+  officialQQLoginMode: 'manual' as 'manual' | 'qrcode',
 
   useWebhook: false,
   webhookPath: '/webhook',
@@ -2798,19 +2811,33 @@ onBeforeMount(async () => {
 
       // 获取二维码
       if (i.adapter?.loginState === goCqHttpStateCode.InLoginQrCode) {
-        store.curDice.qrcodes[i.id] = (await postConnectionQrcode(i.id)).img;
+        store.curDice.qrcodes[i.id] = (await postConnectionQrcode(i.id)).img ?? '';
+      } else if (
+        i.protocolType === 'official' &&
+        i.adapter?.qrLoginState === OfficialQQLoginState.QRWaitingForScan
+      ) {
+        store.curDice.qrcodes[i.id] = (await postConnectionQrcode(i.id)).img ?? '';
       }
 
       if (i.id === curConnId.value) {
         curConn.value = i;
 
         // 登录失败
-        if (i.state !== 1 && i.adapter?.loginState === goCqHttpStateCode.LoginFailed) {
+        if (
+          i.state !== 1 &&
+          (i.adapter?.loginState === goCqHttpStateCode.LoginFailed ||
+            (i.protocolType === 'official' &&
+              i.adapter?.qrLoginState === OfficialQQLoginState.Failed))
+        ) {
           form.isEnd = true;
         }
 
         // 登录成功
-        if (i.state === 1 && i.adapter?.loginState === goCqHttpStateCode.LoginSuccessed) {
+        if (
+          i.state === 1 &&
+          (i.adapter?.loginState === goCqHttpStateCode.LoginSuccessed ||
+            (i.protocolType === 'official' && !i.adapter?.qrLoginState))
+        ) {
           activities.value.push(fullActivities[3]);
           await sleep(1000);
           form.step = 3;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -32,6 +32,14 @@ import { getSalt, signin } from '~/api/signin';
 import type { addImConnectionForm } from '~/components/PageConnectInfoItems.vue';
 import type { AdvancedConfig } from '~/type.d.ts';
 import { toNumber } from 'lodash-es';
+export enum OfficialQQLoginState {
+  Init = 0,
+  QRWaitingForScan = 1,
+  QRScanned = 2,
+  Connecting = 3,
+  Failed = 4,
+}
+
 export enum goCqHttpStateCode {
   Init = 0,
   InLogin = 1,
@@ -98,6 +106,7 @@ export interface AdapterQQ {
   useWebhook?: boolean;
   webhookPath?: string;
   webhookPort?: number;
+  qrLoginState?: OfficialQQLoginState;
 }
 
 interface TalkLogItem {
@@ -321,7 +330,6 @@ export const useStore = defineStore('main', {
         signServerName,
         signServerVersion,
         reverseAddr,
-        onlyQQGuild,
         platform,
         wsGateway,
         restGateway,
@@ -387,8 +395,7 @@ export const useStore = defineStore('main', {
           info = await postAddOfficialQQ(
             appID,
             appSecret,
-            token,
-            onlyQQGuild,
+            false, // onlyQQGuild: 默认全局使用
             useWebhook,
             webhookPath,
             webhookPort,


### PR DESCRIPTION
## Summary by Sourcery

为官方 QQ 机器人添加二维码登录流程，并简化其连接配置。

New Features:
- 在现有登录方式基础上，为官方 QQ 协议连接增加二维码登录支持。
- 在官方 QQ 机器人连接表单中引入可选择的登录模式（手动登录 vs 二维码登录）。

Enhancements:
- 通过移除 token/only-guild 选项并改为单一的 webhook 开关，简化官方 QQ 连接设置。
- 统一 gocq 和官方 QQ 适配器的二维码获取和登录状态处理逻辑。
- 更新类型声明和自动导入，以包含新的适配器状态和 Vue 插槽类型。
- 调整 pnpm 工作区和包配置，使依赖与构建设置对齐，包括加入 PostCSS 的覆盖设置。
- 在全局组件注册表中注册新的 `PagePackage` 组件。

Build:
- 从 `package.json` 中移除仅针对 pnpm 的构建/忽略依赖配置，将构建相关控制迁移到 `pnpm-workspace.yaml`，并在其中添加 PostCSS 版本覆盖。

Documentation:
- 更新官方 QQ 连接的内联帮助文本，说明手动输入凭证和二维码绑定两种登录流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add QR-code based login flow for Official QQ bots and streamline their connection configuration.

New Features:
- Support QR-code login for Official QQ protocol connections alongside existing login methods.
- Introduce a selectable login mode (manual vs QR-code) in the Official QQ bot connection form.

Enhancements:
- Simplify Official QQ connection settings by removing token/only-guild options and switching to a single webhook toggle.
- Unify QR-code retrieval and login state handling across gocq and Official QQ adapters.
- Update type declarations and auto-imports to include new adapter state and Vue slot types.
- Adjust pnpm workspace and package configuration to align dependency and build settings, including a PostCSS override.
- Register the new PagePackage component in the global components registry.

Build:
- Remove pnpm-only built/ignored dependencies configuration from package.json and move build-related controls into pnpm-workspace.yaml with a PostCSS version override.

Documentation:
- Update inline help text for Official QQ connections to explain both manual credential entry and QR-code binding flows.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为官方 QQ 机器人添加二维码登录流程，并简化其连接配置。

New Features:
- 在现有登录方式基础上，为官方 QQ 协议连接增加二维码登录支持。
- 在官方 QQ 机器人连接表单中引入可选择的登录模式（手动登录 vs 二维码登录）。

Enhancements:
- 通过移除 token/only-guild 选项并改为单一的 webhook 开关，简化官方 QQ 连接设置。
- 统一 gocq 和官方 QQ 适配器的二维码获取和登录状态处理逻辑。
- 更新类型声明和自动导入，以包含新的适配器状态和 Vue 插槽类型。
- 调整 pnpm 工作区和包配置，使依赖与构建设置对齐，包括加入 PostCSS 的覆盖设置。
- 在全局组件注册表中注册新的 `PagePackage` 组件。

Build:
- 从 `package.json` 中移除仅针对 pnpm 的构建/忽略依赖配置，将构建相关控制迁移到 `pnpm-workspace.yaml`，并在其中添加 PostCSS 版本覆盖。

Documentation:
- 更新官方 QQ 连接的内联帮助文本，说明手动输入凭证和二维码绑定两种登录流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add QR-code based login flow for Official QQ bots and streamline their connection configuration.

New Features:
- Support QR-code login for Official QQ protocol connections alongside existing login methods.
- Introduce a selectable login mode (manual vs QR-code) in the Official QQ bot connection form.

Enhancements:
- Simplify Official QQ connection settings by removing token/only-guild options and switching to a single webhook toggle.
- Unify QR-code retrieval and login state handling across gocq and Official QQ adapters.
- Update type declarations and auto-imports to include new adapter state and Vue slot types.
- Adjust pnpm workspace and package configuration to align dependency and build settings, including a PostCSS override.
- Register the new PagePackage component in the global components registry.

Build:
- Remove pnpm-only built/ignored dependencies configuration from package.json and move build-related controls into pnpm-workspace.yaml with a PostCSS version override.

Documentation:
- Update inline help text for Official QQ connections to explain both manual credential entry and QR-code binding flows.

</details>

</details>