### PR TITLE
feat(official-qq): 完善 QQ 官方机器人测试与添加流程

### DIFF
--- a/src/api/im_connections/index.ts
+++ b/src/api/im_connections/index.ts
@@ -142,26 +142,56 @@ export function postAddSlack(botToken: string, appToken: string) {
   });
 }
 
+interface TestOfficialQQSuccessBase {
+  result: true;
+  testOnly: true;
+  userId: string;
+  uin: string;
+  nickname: string;
+}
+
+export type TestOfficialQQSuccessResult = TestOfficialQQSuccessBase &
+  ({ exists: false; id?: never } | { exists: true; id: string });
+
+export interface AddOfficialQQSuccessResult {
+  result: true;
+  testOnly?: false;
+  id: string;
+  userId: string;
+  uin: string;
+  nickname?: string;
+}
+
+export interface AddOfficialQQErrorResult {
+  result: false;
+  err: string;
+}
+
+export type AddOfficialQQResult =
+  | TestOfficialQQSuccessResult
+  | AddOfficialQQSuccessResult
+  | AddOfficialQQErrorResult;
+
 export function postAddOfficialQQ(
   appID: string | number,
   appSecret: string,
-  token: string,
+  testOnly: boolean,
   onlyQQGuild: boolean,
   useWebhook: boolean,
   webhookPath: string,
   webhookPort: number,
 ) {
-  return request<DiceConnection>(
+  return request<AddOfficialQQResult>(
     'post',
     'addOfficialQQ',
     {
       appID: String(appID),
       appSecret,
-      token,
+      testOnly,
       onlyQQGuild,
       useWebhook,
-      webhookPath,
-      webhookPort,
+      webhookPath: useWebhook ? webhookPath : '',
+      webhookPort: useWebhook ? webhookPort : 0,
     },
     'json',
     {
@@ -268,7 +298,7 @@ export interface DiceConnection {
   enable: boolean;
   protocolType: string;
   nickname: string;
-  userId: number;
+  userId: string | number;
   groupNum: number;
   cmdExecutedNum: number;
   cmdExecutedLastTime: number;

--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -738,6 +738,28 @@
         能力的限制，一些功能暂时无法实现。</el-alert
       >
       <el-alert
+        v-if="form.accountType === ImConnectionTypeOfficialQQ && officialQQError"
+        type="error"
+        :title="officialQQErrorTitle"
+        :description="officialQQError"
+        :closable="false"
+        show-icon
+        style="margin-bottom: 1.5rem" />
+      <el-alert
+        v-if="form.accountType === ImConnectionTypeOfficialQQ && officialQQTestSucceeded"
+        :type="officialQQExists ? 'error' : 'success'"
+        :title="
+          officialQQExists ? '连接测试成功，但该机器人账号已存在' : 'QQ 官方机器人连接测试成功'
+        "
+        :description="
+          officialQQExists
+            ? `连接测试已通过，账号 QQ：${officialQQUin}`
+            : `连接测试已通过，账号 QQ：${officialQQUin}，可以进入下一步`
+        "
+        :closable="false"
+        show-icon
+        style="margin-bottom: 1.5rem" />
+      <el-alert
         v-if="form.accountType === 14"
         type="warning"
         :closable="false"
@@ -762,7 +784,9 @@
         当前为容器模式，内置客户端被禁用。
       </el-alert>
 
-      <el-form :model="form">
+      <el-form
+        :model="form"
+        :disabled="form.accountType === ImConnectionTypeOfficialQQ && officialQQSubmitting">
         <el-form-item label="账号类型" :label-width="formLabelWidth">
           <el-select v-model="selectedAccountPlatform" filterable :clearable="false">
             <el-option label="QQ" value="QQ"></el-option>
@@ -1479,24 +1503,14 @@
         </el-form-item>
         <el-form-item
           v-if="form.accountType === ImConnectionTypeOfficialQQ"
-          label="机器人令牌"
-          :label-width="formLabelWidth"
-          required>
-          <el-input
-            v-model="form.token"
-            placeholder="填写在开放平台获取的Token"
-            type="text"
-            autocomplete="off"></el-input>
-        </el-form-item>
-        <el-form-item
-          v-if="form.accountType === ImConnectionTypeOfficialQQ"
           label="机器人密钥"
           :label-width="formLabelWidth"
           required>
           <el-input
             v-model="form.appSecret"
             placeholder="填写在开放平台获取的AppSecret"
-            type="text"
+            type="password"
+            show-password
             autocomplete="off"></el-input>
         </el-form-item>
         <el-form-item
@@ -2014,8 +2028,31 @@
     <template #footer>
       <span class="dialog-footer">
         <template v-if="form.step === 1">
-          <el-button @click="dialogFormVisible = false">取消</el-button>
+          <el-button :disabled="officialQQSubmitting" @click="cancelConnectionForm">取消</el-button>
+          <template v-if="form.accountType === ImConnectionTypeOfficialQQ">
+            <el-button
+              :loading="officialQQTesting"
+              :disabled="
+                officialQQSubmitting ||
+                officialQQTestSucceeded ||
+                form.appID === undefined ||
+                form.appID === '' ||
+                form.appSecret === '' ||
+                (form.useWebhook && (form.webhookPath === '' || form.webhookPort === undefined))
+              "
+              @click="submitOfficialQQTest">
+              测试连接
+            </el-button>
+            <el-button
+              type="primary"
+              :loading="officialQQAdding"
+              :disabled="officialQQSubmitting || !officialQQTestSucceeded || officialQQExists"
+              @click="submitOfficialQQ">
+              添加
+            </el-button>
+          </template>
           <el-button
+            v-else
             type="primary"
             :disabled="
               form.accountType === ImConnectionTypeGocqLegacy ||
@@ -2044,17 +2081,11 @@
                   form.signServerName === '')) ||
               (form.accountType === ImConnectionTypeMilkySeparate &&
                 (form.wsGateway === '' || form.restGateway === '')) ||
-              (isInternalMilkyAccountType(form.accountType) && form.account === '') ||
-              (form.accountType === ImConnectionTypeOfficialQQ &&
-                (form.appID === undefined ||
-                  form.appID === '' ||
-                  form.token === '' ||
-                  form.appSecret === '' ||
-                  (form.useWebhook && (form.webhookPath === '' || form.webhookPort === undefined))))
+              (isInternalMilkyAccountType(form.accountType) && form.account === '')
             "
             @click="goStepTwo">
-            下一步</el-button
-          >
+            下一步
+          </el-button>
         </template>
         <template v-if="form.isEnd">
           <el-button @click="formClose">确定</el-button>
@@ -2230,6 +2261,15 @@ const duringRelogin = ref(false);
 const dialogFormVisible = ref(false);
 const dialogSetDataFormVisible = ref(false);
 const dialogSlideVisible = ref(false);
+const officialQQTesting = ref(false);
+const officialQQAdding = ref(false);
+const officialQQSubmitting = computed(() => officialQQTesting.value || officialQQAdding.value);
+const officialQQTestSucceeded = ref(false);
+const officialQQUin = ref('');
+const officialQQNickname = ref('');
+const officialQQExists = ref(false);
+const officialQQErrorTitle = ref('');
+const officialQQError = ref('');
 const formLabelWidth = '120px';
 const isTestMode = ref(false);
 
@@ -2369,6 +2409,122 @@ const openSocks = async () => {
   }
 };
 
+const resetOfficialQQTestResult = () => {
+  officialQQTestSucceeded.value = false;
+  officialQQUin.value = '';
+  officialQQNickname.value = '';
+  officialQQExists.value = false;
+};
+
+const getRequestErrorMessage = (error: unknown, fallback = '连接测试请求失败') => {
+  if (typeof error === 'object' && error !== null && 'response' in error) {
+    const response = (error as { response?: { data?: unknown } }).response;
+    const data = response?.data;
+    if (typeof data === 'string' && data) return data;
+    if (typeof data === 'object' && data !== null && 'err' in data) {
+      const err = (data as { err?: unknown }).err;
+      if (typeof err === 'string' && err) return err;
+    }
+  }
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === 'string' && error) return error;
+  return fallback;
+};
+
+const submitOfficialQQTest = async () => {
+  if (officialQQSubmitting.value) return;
+
+  officialQQTesting.value = true;
+  resetOfficialQQTestResult();
+  officialQQErrorTitle.value = '';
+  officialQQError.value = '';
+
+  try {
+    const result = await store.addImConnection(form, true);
+    if (!('result' in result)) {
+      throw new Error('连接测试返回了无效结果');
+    }
+    if (!result.result) {
+      officialQQErrorTitle.value = 'QQ 官方机器人连接测试失败';
+      officialQQError.value = result.err;
+      form.step = 1;
+      return;
+    }
+    if (result.testOnly !== true) {
+      throw new Error('连接测试返回了非测试结果');
+    }
+
+    officialQQUin.value = result.uin;
+    officialQQNickname.value = result.nickname;
+    officialQQExists.value = result.exists;
+    officialQQTestSucceeded.value = true;
+  } catch (error) {
+    officialQQErrorTitle.value = 'QQ 官方机器人连接测试请求失败';
+    officialQQError.value = getRequestErrorMessage(error);
+    form.step = 1;
+  } finally {
+    officialQQTesting.value = false;
+  }
+};
+
+const submitOfficialQQ = async () => {
+  if (officialQQSubmitting.value || !officialQQTestSucceeded.value || officialQQExists.value) {
+    return;
+  }
+
+  officialQQAdding.value = true;
+  officialQQErrorTitle.value = '';
+  officialQQError.value = '';
+
+  try {
+    const result = await store.addImConnection(form, false);
+    if (!('result' in result)) {
+      throw new Error('添加请求返回了无效结果');
+    }
+    if (!result.result) {
+      officialQQErrorTitle.value = 'QQ 官方机器人添加失败';
+      officialQQError.value = result.err;
+      return;
+    }
+    if (result.testOnly === true) {
+      throw new Error('添加请求返回了测试结果');
+    }
+
+    const { id, userId, uin } = result;
+    curConnId.value = id;
+    try {
+      const connections = await store.getImConnections();
+      const addedConnection =
+        connections.find(connection => connection.id === id) ??
+        connections.find(connection => String(connection.userId) === userId) ??
+        connections.find(connection => String(connection.userId) === `OpenQQ:${uin}`);
+      if (addedConnection) curConn.value = addedConnection;
+    } catch (error) {
+      ElMessage.error(`账号已添加，但连接列表刷新失败：${getRequestErrorMessage(error)}`);
+    }
+
+    ElMessage.success('QQ 官方机器人添加成功');
+    dialogFormVisible.value = false;
+    form.account = '';
+    form.step = 1;
+    resetOfficialQQTestResult();
+  } catch (error) {
+    officialQQErrorTitle.value = 'QQ 官方机器人添加请求失败';
+    officialQQError.value = getRequestErrorMessage(error, '添加请求失败');
+  } finally {
+    officialQQAdding.value = false;
+  }
+};
+
+const cancelConnectionForm = () => {
+  if (officialQQSubmitting.value) return;
+
+  dialogFormVisible.value = false;
+  resetOfficialQQTestResult();
+  officialQQErrorTitle.value = '';
+  officialQQError.value = '';
+};
+
 const goStepTwo = async () => {
   form.step = 2;
   curConnId.value = '';
@@ -2378,7 +2534,11 @@ const goStepTwo = async () => {
   store
     .addImConnection(form as any)
     .then(conn => {
-      if ((conn as any).testMode) {
+      if ('result' in conn) {
+        if (!conn.result) throw new Error(conn.err);
+        if (conn.testOnly === true) throw new Error('添加请求返回了测试结果');
+        curConnId.value = conn.id;
+      } else if ((conn as any).testMode) {
         isTestMode.value = true;
       } else {
         curConnId.value = conn.id;
@@ -2742,6 +2902,22 @@ const form = reactive({
   builtInMode: '',
 });
 
+watch(
+  () => [
+    form.appID,
+    form.appSecret,
+    form.useWebhook,
+    form.useWebhook ? form.webhookPath : '',
+    form.useWebhook ? form.webhookPort : 0,
+  ],
+  () => {
+    resetOfficialQQTestResult();
+    officialQQErrorTitle.value = '';
+    officialQQError.value = '';
+  },
+  { flush: 'sync' },
+);
+
 const selectedAccountPlatform = computed<number | 'QQ'>({
   get: () => (isQQAccountType(form.accountType) ? 'QQ' : form.accountType),
   set: accountType => {
@@ -2758,6 +2934,9 @@ export type addImConnectionForm = typeof form;
 
 // 添加一个新账号
 const addOne = () => {
+  resetOfficialQQTestResult();
+  officialQQErrorTitle.value = '';
+  officialQQError.value = '';
   dialogFormVisible.value = true;
   form.protocol = 6;
   form.implementation = 'gocq';

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -25,6 +25,7 @@ import {
   postaddSealChat,
   postAddSlack,
   postAddTelegram,
+  type AddOfficialQQResult,
 } from '~/api/im_connections';
 import { getBaseInfo, getHello, getLogFetchAndClear, getPreInfo } from '~/api/others';
 import { getSalt, signin } from '~/api/signin';
@@ -115,7 +116,7 @@ export interface DiceConnection {
   enable: boolean;
   protocolType: string;
   nickname: string;
-  userId: number;
+  userId: string | number;
   groupNum: number;
   cmdExecutedNum: number;
   cmdExecutedLastTime: number;
@@ -291,7 +292,10 @@ export const useStore = defineStore('main', {
       return info;
     },
 
-    async addImConnection(form: addImConnectionForm) {
+    async addImConnection(
+      form: addImConnectionForm,
+      officialQQTestOnly = false,
+    ): Promise<DiceConnection | AddOfficialQQResult> {
       const {
         accountType,
         nickname,
@@ -331,7 +335,7 @@ export const useStore = defineStore('main', {
         webhookPort,
       } = form;
 
-      let info = null;
+      let info: DiceConnection | AddOfficialQQResult | null = null;
       switch (accountType) {
         //QQ
         case ImConnectionTypeGocqLegacy:
@@ -387,7 +391,7 @@ export const useStore = defineStore('main', {
           info = await postAddOfficialQQ(
             appID,
             appSecret,
-            token,
+            officialQQTestOnly,
             onlyQQGuild,
             useWebhook,
             webhookPath,
@@ -435,7 +439,10 @@ export const useStore = defineStore('main', {
           }
           break;
       }
-      return info as DiceConnection;
+      if (info === null) {
+        throw new Error('添加账号接口未返回结果');
+      }
+      return info;
     },
     async logFetchAndClear() {
       const info = await getLogFetchAndClear();


### PR DESCRIPTION
## Summary by Sourcery

改进 QQ 公众号机器人连接流程，增加专用测试和添加步骤，优化错误处理与界面反馈。

新功能：
- 为 QQ 公众号机器人增加单独的连接测试步骤，并提供专门的成功与错误提示。
- 为 QQ 公众号机器人引入独立的账号添加步骤，在最终创建账号前使用已测试通过的连接数据。

缺陷修复：
- 在 QQ 公众号机器人请求进行期间，阻止表单提交和对话框取消操作，以避免出现不一致的状态。

改进优化：
- 简化 QQ 公众号机器人凭据配置，移除 token 字段，并将 AppSecret 视为密码输入。
- 当凭据或 webhook 设置变更，以及在打开或取消添加账号对话框时，重置 QQ 公众号机器人的测试状态和错误信息。
- 明确处理 QQ 公众号机器人后端响应，包括仅测试结果与已存在账号的检测，并相应更新当前连接列表。
- 泛化 DiceConnection 的 userId，以在 API 和存储层面支持字符串标识符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the QQ official bot connection flow with dedicated test and add steps, refined error handling, and UI feedback.

New Features:
- Add a separate connection test step for QQ official bots with dedicated success and error alerts.
- Introduce a dedicated add step for QQ official bots that uses the tested connection data before finalizing account creation.

Bug Fixes:
- Prevent form submission and dialog cancellation while QQ official bot requests are in progress to avoid inconsistent states.

Enhancements:
- Simplify QQ official bot credentials by removing the token field and treating AppSecret as a password input.
- Reset QQ official bot test state and errors when credentials or webhook settings change, and when opening or canceling the add-account dialog.
- Handle QQ official bot backend responses explicitly, including test-only results and existing-account detection, and update the current connection list accordingly.
- Generalize DiceConnection userId to support string identifiers in both API and store layers.

</details>