### PR TITLE
chore: 安抚一下review dog

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,27 +1,26 @@
 name: Review Dog
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '**.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue}'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - '.github/workflows/reviewdog.yml'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   review-dog:
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
     name: Review Dog
     runs-on: ubuntu-latest
     steps:
       - name: Code
         uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
@@ -42,4 +41,4 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pnpm exec eslint -f rdjson . | reviewdog -f=rdjson -reporter=github-pr-review -filter-mode=nofilter -fail-level=any
+          pnpm exec eslint -f rdjson . | reviewdog -f=rdjson -reporter=github-pr-annotations -filter-mode=nofilter -fail-level=any


### PR DESCRIPTION
## Summary by Sourcery

在拉取请求事件上运行 reviewdog，并更新权限配置，同时停止跟踪自动生成的 TypeScript 声明文件。

CI：
- 修改 reviewdog 工作流，使其在 `pull_request` 事件上运行，使用只读的仓库和拉取请求权限，并通过 PR 注释报告 ESLint 结果。

Chores：
- 从版本控制中移除自动生成的 TypeScript 声明文件（`auto-imports.d.ts` 和 `components.d.ts`）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Run reviewdog on pull request events with updated permissions and stop tracking generated TypeScript declaration files.

CI:
- Change reviewdog workflow to run on pull_request with read-only repository and pull request permissions and report ESLint results via PR annotations.

Chores:
- Remove auto-generated TypeScript declaration files (auto-imports.d.ts and components.d.ts) from version control.

</details>

CI：
- 在 `pull_request` 事件中运行 reviewdog，使用更新后的 GitHub 权限，并通过 PR 注释显示 ESLint 报告。

杂项：
- 停止跟踪自动生成的 TypeScript 声明文件 `auto-imports.d.ts` 和 `components.d.ts`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在拉取请求事件上运行 reviewdog，并更新权限配置，同时停止跟踪自动生成的 TypeScript 声明文件。

CI：
- 修改 reviewdog 工作流，使其在 `pull_request` 事件上运行，使用只读的仓库和拉取请求权限，并通过 PR 注释报告 ESLint 结果。

Chores：
- 从版本控制中移除自动生成的 TypeScript 声明文件（`auto-imports.d.ts` 和 `components.d.ts`）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Run reviewdog on pull request events with updated permissions and stop tracking generated TypeScript declaration files.

CI:
- Change reviewdog workflow to run on pull_request with read-only repository and pull request permissions and report ESLint results via PR annotations.

Chores:
- Remove auto-generated TypeScript declaration files (auto-imports.d.ts and components.d.ts) from version control.

</details>

</details>

CI：
- 修改 reviewdog 工作流为在 `pull_request` 上运行，调整 GitHub 权限设置，并将 reviewdog 的报告方式切换为使用 GitHub PR 注释。

Chores：
- 从版本控制中删除自动生成的 TypeScript 声明文件（`auto-imports.d.ts` 和 `components.d.ts`）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在拉取请求事件上运行 reviewdog，并更新权限配置，同时停止跟踪自动生成的 TypeScript 声明文件。

CI：
- 修改 reviewdog 工作流，使其在 `pull_request` 事件上运行，使用只读的仓库和拉取请求权限，并通过 PR 注释报告 ESLint 结果。

Chores：
- 从版本控制中移除自动生成的 TypeScript 声明文件（`auto-imports.d.ts` 和 `components.d.ts`）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Run reviewdog on pull request events with updated permissions and stop tracking generated TypeScript declaration files.

CI:
- Change reviewdog workflow to run on pull_request with read-only repository and pull request permissions and report ESLint results via PR annotations.

Chores:
- Remove auto-generated TypeScript declaration files (auto-imports.d.ts and components.d.ts) from version control.

</details>

CI：
- 在 `pull_request` 事件中运行 reviewdog，使用更新后的 GitHub 权限，并通过 PR 注释显示 ESLint 报告。

杂项：
- 停止跟踪自动生成的 TypeScript 声明文件 `auto-imports.d.ts` 和 `components.d.ts`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在拉取请求事件上运行 reviewdog，并更新权限配置，同时停止跟踪自动生成的 TypeScript 声明文件。

CI：
- 修改 reviewdog 工作流，使其在 `pull_request` 事件上运行，使用只读的仓库和拉取请求权限，并通过 PR 注释报告 ESLint 结果。

Chores：
- 从版本控制中移除自动生成的 TypeScript 声明文件（`auto-imports.d.ts` 和 `components.d.ts`）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Run reviewdog on pull request events with updated permissions and stop tracking generated TypeScript declaration files.

CI:
- Change reviewdog workflow to run on pull_request with read-only repository and pull request permissions and report ESLint results via PR annotations.

Chores:
- Remove auto-generated TypeScript declaration files (auto-imports.d.ts and components.d.ts) from version control.

</details>

</details>

</details>