### PR TITLE
fix(official-qq): close QR login dialog on failure

### DIFF
--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -3026,13 +3026,18 @@ onBeforeMount(async () => {
         curConn.value = i;
 
         // 登录失败
+        const officialQQQrLoginFailed =
+          i.protocolType === 'official' && i.adapter?.qrLoginState === OfficialQQLoginState.Failed;
         if (
           i.state !== 1 &&
-          (i.adapter?.loginState === goCqHttpStateCode.LoginFailed ||
-            (i.protocolType === 'official' &&
-              i.adapter?.qrLoginState === OfficialQQLoginState.Failed))
+          (i.adapter?.loginState === goCqHttpStateCode.LoginFailed || officialQQQrLoginFailed)
         ) {
-          form.isEnd = true;
+          if (officialQQQrLoginFailed) {
+            formClose();
+            ElMessage.error('QQ 官方机器人扫码登录失败，请检查账号是否已重复添加');
+          } else {
+            form.isEnd = true;
+          }
         }
 
         // 登录成功


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保 QQ 官方二维码登录失败时，能够正确关闭登录对话框，并显示适当的错误消息，而不是让表单处于不一致的结束状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure QQ official QR login failures correctly close the login dialog and surface an appropriate error message instead of leaving the form in an inconsistent end state.

</details>