### PR TITLE
fix(ui): 完善账号列表加载与失败状态

### DIFF
--- a/src/api/im_connections/index.ts
+++ b/src/api/im_connections/index.ts
@@ -4,7 +4,7 @@ const baseUrl = '/im_connections/';
 const request = createRequest(baseUrl);
 
 export function getConnectionList() {
-  return request<DiceConnection[]>('get', 'list');
+  return request<DiceConnection[] | null>('get', 'list');
 }
 
 export function getConnectQQVersion() {

--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- <div style="position: relative;"> -->
-  <Teleport to="#root">
+  <Teleport v-if="!connectionsLoading" to="#root">
     <div style="position: absolute; right: 40px; bottom: 60px; z-index: 10">
       <!--    <el-button type="primary" class="btn-add" :icon="Plus" circle @click="addOne"></el-button>-->
       <el-button type="primary" class="btn-add" :icon="Plus" circle @click="addOne"></el-button>
@@ -8,14 +8,16 @@
   </Teleport>
   <!-- </div> -->
 
-  <div v-if="!store.curDice.conns || (store.curDice.conns && store.curDice.conns.length === 0)">
+  <div v-if="connectionsLoading" v-loading="true" style="min-height: 4rem"></div>
+
+  <div v-else-if="store.curDice.conns.length === 0">
     <span style="vertical-align: middle">似乎还没有账号，</span>
     <el-link style="font-size: 16px; font-weight: bolder" type="primary" @click="addOne"
       >点我添加一个</el-link
     >
   </div>
 
-  <div style="display: flex; flex-wrap: wrap">
+  <div v-else style="display: flex; flex-wrap: wrap">
     <div
       v-for="(i, index) in reactive(store.curDice.conns)"
       :key="index"
@@ -2250,6 +2252,7 @@ const fullActivities = [
 const activities = ref([] as typeof fullActivities);
 
 const store = useStore();
+const connectionsLoading = ref(true);
 const curCaptchaIdSet = ref(''); // 当前设置了 ticket 的 id
 
 const isContainerMode = () => {
@@ -2982,15 +2985,21 @@ const addOne = () => {
   getSignInfo();
 };
 
-let timerId: number;
+let pageUnmounted = false;
+let timerId: number | undefined;
 
 onBeforeMount(async () => {
   await store.getImConnections();
+  if (pageUnmounted) return;
+
+  connectionsLoading.value = false;
   for (const i of store.curDice.conns || []) {
     delete store.curDice.qrcodes[i.id];
   }
 
   const versionsRes = await getConnectQQVersion();
+  if (pageUnmounted) return;
+
   if (versionsRes.result) {
     supportedQQVersions.value = ['', ...versionsRes.versions];
   }
@@ -3059,7 +3068,8 @@ onBeforeMount(async () => {
 });
 
 onBeforeUnmount(() => {
-  clearInterval(timerId);
+  pageUnmounted = true;
+  if (timerId !== undefined) clearInterval(timerId);
 });
 
 const doRemove = async (i: DiceConnection) => {

--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -12,7 +12,7 @@
 
   <div v-else-if="connectionsLoadFailed">获取账号列表失败，请稍后重试</div>
 
-  <div v-else-if="store.curDice.conns.length === 0">
+  <div v-else-if="!store.curDice.conns?.length">
     <span style="vertical-align: middle">似乎还没有账号，</span>
     <el-link style="font-size: 16px; font-weight: bolder" type="primary" @click="addOne"
       >点我添加一个</el-link

--- a/src/components/PageConnectInfoItems.vue
+++ b/src/components/PageConnectInfoItems.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- <div style="position: relative;"> -->
-  <Teleport v-if="!connectionsLoading" to="#root">
+  <Teleport v-if="!connectionsLoading && !connectionsLoadFailed" to="#root">
     <div style="position: absolute; right: 40px; bottom: 60px; z-index: 10">
       <!--    <el-button type="primary" class="btn-add" :icon="Plus" circle @click="addOne"></el-button>-->
       <el-button type="primary" class="btn-add" :icon="Plus" circle @click="addOne"></el-button>
@@ -9,6 +9,8 @@
   <!-- </div> -->
 
   <div v-if="connectionsLoading" v-loading="true" style="min-height: 4rem"></div>
+
+  <div v-else-if="connectionsLoadFailed">获取账号列表失败，请稍后重试</div>
 
   <div v-else-if="store.curDice.conns.length === 0">
     <span style="vertical-align: middle">似乎还没有账号，</span>
@@ -2253,6 +2255,7 @@ const activities = ref([] as typeof fullActivities);
 
 const store = useStore();
 const connectionsLoading = ref(true);
+const connectionsLoadFailed = ref(false);
 const curCaptchaIdSet = ref(''); // 当前设置了 ticket 的 id
 
 const isContainerMode = () => {
@@ -2989,10 +2992,21 @@ let pageUnmounted = false;
 let timerId: number | undefined;
 
 onBeforeMount(async () => {
-  await store.getImConnections();
+  try {
+    await store.getImConnections();
+  } catch {
+    if (!pageUnmounted) {
+      connectionsLoadFailed.value = true;
+      ElMessage.error('获取账号列表失败，请稍后重试');
+    }
+  } finally {
+    if (!pageUnmounted) {
+      connectionsLoading.value = false;
+    }
+  }
+
   if (pageUnmounted) return;
 
-  connectionsLoading.value = false;
   for (const i of store.curDice.conns || []) {
     delete store.curDice.qrcodes[i.id];
   }
@@ -3011,6 +3025,7 @@ onBeforeMount(async () => {
   timerId = setInterval(async () => {
     console.log('refresh');
     await store.getImConnections();
+    connectionsLoadFailed.value = false;
 
     for (const i of store.curDice.conns || []) {
       // 下一轮登录检查，移除二维码

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -229,8 +229,9 @@ export const useStore = defineStore('main', {
 
     async getImConnections() {
       const info = await getConnectionList();
-      this.diceServers[this.index].conns = info;
-      return info;
+      const connections = info ?? [];
+      this.diceServers[this.index].conns = connections;
+      return connections;
     },
 
     async addImConnection(


### PR DESCRIPTION
此 PR 修复了如下问题：

- 在页面卸载后，轮询会导致在其他页面仍显示 empty state

此 PR 优化了如下问题：

- 将账号列表页面的 empty state，loading state 和 error state 分离，避免使用 empty state 处理所有无数据显示；
- 增加 error state。

## Summary by Sourcery

为账户列表页面分别处理加载中、空数据和错误状态，并防止在页面卸载后轮询继续更新状态。

Bug Fixes:
- 在页面卸载后停止账户列表的轮询和状态更新，避免错误地显示为空状态。

Enhancements:
- 为账户列表引入独立的加载中和错误状态，将其与空数据状态区分开来，并在数据成功加载后才渲染“添加”按钮。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle distinct loading, empty, and error states for the account list page and prevent polling from updating state after page unmount.

Bug Fixes:
- Stop account list polling and state updates after the page is unmounted to avoid incorrect empty state display.

Enhancements:
- Introduce explicit loading and error states for the account list, separate from the empty data state, and gate the add button rendering on successful data load.

</details>