### PR TITLE
feat(notice): 通知列表与骰主列表分离，支持自定义通知对象

### DIFF
--- a/src/api/dice/index.ts
+++ b/src/api/dice/index.ts
@@ -1,6 +1,8 @@
 import type { AdvancedConfig } from '~/type';
 import { createRequest } from '..';
 
+export * from './noticeCodec';
+
 const baseUrl = '/dice/';
 const request = createRequest(baseUrl);
 

--- a/src/api/dice/noticeCodec.ts
+++ b/src/api/dice/noticeCodec.ts
@@ -1,0 +1,160 @@
+// 通知分类与通知 ID 字符串后缀编解码工具。
+//
+// 后端仍以字符串数组存储配置（保持向后兼容），格式为：
+//   - QQ:12345                      启用全部分类
+//   - QQ:12345:disable              禁用
+//   - QQ:12345:only=group,ban       仅接收群组与黑名单相关通知
+//   - QQ:12345:only=send:disable    顺序可换，元数据仅从末尾识别
+// 持久化时由后端按统一顺序写回，因此 UI 不直接显示后缀。
+export type NoticeCategory = 'group' | 'invite' | 'ban' | 'censor' | 'inactive' | 'send' | 'system';
+
+export const ALL_NOTICE_CATEGORIES: NoticeCategory[] = [
+  'group',
+  'invite',
+  'ban',
+  'censor',
+  'inactive',
+  'send',
+  'system',
+];
+
+export const NOTICE_CATEGORY_LABELS: Record<NoticeCategory, string> = {
+  group: '群组事件',
+  invite: '邀请事件',
+  ban: '黑名单事件',
+  censor: '敏感词事件',
+  inactive: '不活跃群清理',
+  send: 'send 留言',
+  system: '系统事件',
+};
+
+export const NOTICE_CATEGORY_DESCRIPTIONS: Record<NoticeCategory, string> = {
+  group: '入群、退群、被踢、被禁言、自动激活、手动退群等',
+  invite: '群邀请与好友邀请',
+  ban: '黑名单等级提升、黑名单用户/群处理',
+  censor: '敏感词处理器配置为“通知骰主”时的提示',
+  inactive: '自动清理不活跃群组的逐条或摘要通知',
+  send: '用户通过 .send 指令的留言',
+  system: '存活确认、连接中断、账号风控等系统通知',
+};
+
+export interface NoticeItem {
+  id: string;
+  enabled: boolean;
+  categories: NoticeCategory[];
+  // 内部状态：是否启用了自定义分类；无变化时不上报后端。
+  categoriesDirty: boolean;
+}
+
+const META_SUFFIX_DISABLE = 'disable';
+const META_PREFIX_ONLY = 'only=';
+
+function splitOnly(value: string): NoticeCategory[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(',')
+    .map(part => part.trim())
+    .filter((part): part is NoticeCategory => (ALL_NOTICE_CATEGORIES as string[]).includes(part));
+}
+
+// decodeNoticeId 解析一条持久化通知目标字符串。
+export function decodeNoticeId(raw: string): NoticeItem {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) {
+    return { id: '', enabled: true, categories: [], categoriesDirty: false };
+  }
+
+  // Mail: 邮箱类型不支持元数据，沿用旧行为。
+  if (trimmed.startsWith('Mail:')) {
+    return {
+      id: trimmed,
+      enabled: true,
+      categories: [],
+      categoriesDirty: false,
+    };
+  }
+
+  const parts = trimmed.split(':');
+  let end = parts.length;
+  let enabled = true;
+  let categories: NoticeCategory[] = [];
+  let categoriesDirty = false;
+
+  while (end > 1) {
+    const suffix = parts[end - 1].trim();
+    if (suffix === META_SUFFIX_DISABLE) {
+      enabled = false;
+      end -= 1;
+      continue;
+    }
+    if (suffix.startsWith(META_PREFIX_ONLY)) {
+      // 取最右侧的 only= 作为最终生效值。
+      if (!categoriesDirty) {
+        categories = splitOnly(suffix.slice(META_PREFIX_ONLY.length));
+        categoriesDirty = true;
+      }
+      end -= 1;
+      continue;
+    }
+    break;
+  }
+
+  return {
+    id: parts.slice(0, end).join(':'),
+    enabled,
+    categories,
+    categoriesDirty,
+  };
+}
+
+// encodeNoticeId 将 UI 状态编码为持久化字符串。
+export function encodeNoticeId(item: NoticeItem): string {
+  const id = (item.id ?? '').trim();
+  if (!id) {
+    return '';
+  }
+  if (id.startsWith('Mail:')) {
+    return id;
+  }
+  const segments: string[] = [id];
+  if (!item.enabled) {
+    segments.push(META_SUFFIX_DISABLE);
+  }
+  if (item.categoriesDirty) {
+    if (item.categories.length === 0) {
+      segments.push(`${META_PREFIX_ONLY}`);
+    } else {
+      segments.push(`${META_PREFIX_ONLY}${item.categories.join(',')}`);
+    }
+  }
+  return segments.join(':');
+}
+
+// fromNoticeItems 将 UI 状态数组转回字符串数组，过滤空项。
+export function fromNoticeItems(items: NoticeItem[]): string[] {
+  return items.map(encodeNoticeId).filter(value => value !== '');
+}
+
+// toNoticeItems 将字符串数组展开为 UI 状态。
+export function toNoticeItems(list: string[] | undefined | null): NoticeItem[] {
+  return (list ?? []).map(decodeNoticeId);
+}
+
+export function noticeItemPlatform(id: string): string | null {
+  if (!id) {
+    return null;
+  }
+  const colon = id.indexOf(':');
+  if (colon === -1) {
+    return null;
+  }
+  const prefix = id.slice(0, colon);
+  const dash = prefix.indexOf('-');
+  return (dash === -1 ? prefix : prefix.slice(0, dash)) || null;
+}
+
+export function isMailNoticeItem(id: string): boolean {
+  return id.startsWith('Mail:');
+}

--- a/src/components/misc/PageMiscSettings.vue
+++ b/src/components/misc/PageMiscSettings.vue
@@ -87,41 +87,59 @@
           <span>消息通知列表</span>
           <el-tooltip
             raw-content
-            content="会对以下消息进行通知:<br>加群邀请、好友邀请、进入群组、被踢出群、被禁言、自动激活、指令退群<br>单行格式: QQ:12345 QQ-Group:12345 Mail:abc@foo.bar<br>通知列表中的QQ号在发件时会自动转换成对应邮箱">
+            content="每项可独立启用与选择通知分类。<br>支持的前缀：QQ:、QQ-Group:、QQ-CH-Group:、Mail:、…<br>Mail: 邮箱类型不支持禁用或分类筛选。">
             <el-icon><question-filled /></el-icon>
           </el-tooltip>
         </div>
       </template>
 
-      <template v-if="config.noticeIds && config.noticeIds.length">
+      <template v-if="noticeItems.length">
         <div
           :key="index"
-          v-for="(k2, index) in config.noticeIds"
+          v-for="(item, index) in noticeItems"
           style="width: 100%; margin-bottom: 0.5rem">
-          <!-- 这里面是单条修改项 -->
-          <div style="display: flex">
-            <div>
-              <!-- :suffix-icon="Management" -->
-              <el-input v-model="config.noticeIds[index]" :autosize="true"></el-input>
-            </div>
-            <div style="display: flex; align-items: center; width: 1.3rem; margin-left: 1rem">
-              <el-tooltip
-                :content="index === 0 ? '点击添加项目' : '点击删除你不想要的项'"
-                placement="bottom-start">
-                <el-icon>
-                  <circle-plus-filled
-                    v-if="index == 0"
-                    @click="config.noticeIds = addItem(config.noticeIds)" />
-                  <circle-close v-else @click="removeItem(config.noticeIds, index)" />
-                </el-icon>
-              </el-tooltip>
-            </div>
+          <div style="display: flex; align-items: center; gap: 0.5rem">
+            <el-checkbox v-model="item.enabled" :disabled="isMailNoticeItem(item.id)" />
+            <el-input
+              v-model="item.id"
+              :autosize="true"
+              :placeholder="noticeItemPlaceholder"
+              style="flex: 1"
+              @change="onNoticeItemIdChanged(item)" />
+            <el-select
+              v-model="item.categories"
+              multiple
+              collapse-tags
+              collapse-tags-tooltip
+              :disabled="!item.enabled || isMailNoticeItem(item.id)"
+              placeholder="通知分类"
+              style="width: 18rem"
+              @change="markCategoriesDirty(item)">
+              <el-option
+                v-for="option in noticeCategoryOptions"
+                :key="option.value"
+                :label="option.label"
+                :value="option.value">
+                <div style="display: flex; flex-direction: column; line-height: 1.2">
+                  <span>{{ option.label }}</span>
+                  <el-text type="info" size="small">{{ option.description }}</el-text>
+                </div>
+              </el-option>
+            </el-select>
+            <el-tooltip
+              :content="index === 0 ? '点击添加项目' : '点击删除你不想要的项'"
+              placement="bottom-start">
+              <el-icon>
+                <circle-plus-filled v-if="index == 0" @click="addNoticeItem" />
+                <circle-close v-else @click="removeNoticeItem(index)" />
+              </el-icon>
+            </el-tooltip>
           </div>
         </div>
       </template>
       <template v-else>
         <el-icon>
-          <circle-plus-filled @click="config.noticeIds = addItem(config.noticeIds)" />
+          <circle-plus-filled @click="addNoticeItem" />
         </el-icon>
       </template>
     </el-form-item>
@@ -745,6 +763,15 @@
 import { CirclePlusFilled, CircleClose, QuestionFilled, Upload } from '@element-plus/icons-vue';
 import { cloneDeep, toNumber } from 'lodash-es';
 import { postMailTest, postUploadToUpgrade } from '~/api/dice';
+import {
+  ALL_NOTICE_CATEGORIES,
+  NOTICE_CATEGORY_DESCRIPTIONS,
+  NOTICE_CATEGORY_LABELS,
+  fromNoticeItems,
+  isMailNoticeItem,
+  toNoticeItems,
+  type NoticeItem,
+} from '~/api/dice/noticeCodec';
 import { useStore } from '~/store';
 import { objDiff, passwordHash } from '~/utils';
 
@@ -756,6 +783,50 @@ const fileList = ref<any[]>([]);
 const isShowUnlockCode = ref(false);
 const modified = ref(false);
 const isUploadEnable = ref(false);
+
+const noticeItems = ref<NoticeItem[]>([]);
+
+const noticeItemPlaceholder = '例如 QQ:12345 / QQ-Group:12345 / Mail:foo@bar.com';
+
+const noticeCategoryOptions = ALL_NOTICE_CATEGORIES.map(value => ({
+  value,
+  label: NOTICE_CATEGORY_LABELS[value],
+  description: NOTICE_CATEGORY_DESCRIPTIONS[value],
+}));
+
+function syncNoticeItemsFromConfig() {
+  noticeItems.value = toNoticeItems(config.value.noticeIds);
+}
+
+function addNoticeItem() {
+  noticeItems.value.push({
+    id: '',
+    enabled: true,
+    categories: [],
+    categoriesDirty: false,
+  });
+}
+
+function removeNoticeItem(index: number) {
+  noticeItems.value.splice(index, 1);
+}
+
+function onNoticeItemIdChanged(item: NoticeItem) {
+  if (isMailNoticeItem(item.id)) {
+    item.enabled = true;
+    item.categories = [];
+    item.categoriesDirty = false;
+  }
+}
+
+function markCategoriesDirty(item: NoticeItem) {
+  if (isMailNoticeItem(item.id)) {
+    item.categories = [];
+    item.categoriesDirty = false;
+    return;
+  }
+  item.categoriesDirty = true;
+}
 
 const beforeUpload = async (file: any) => {
   // UploadRawFile
@@ -805,6 +876,7 @@ onBeforeMount(async () => {
     val.commandPrefix = [''];
   }
   config.value = val;
+  syncNoticeItemsFromConfig();
   nextTick(() => {
     modified.value = false;
   });
@@ -812,6 +884,7 @@ onBeforeMount(async () => {
 
 const submitGiveup = async () => {
   config.value = cloneDeep(store.curDice.config);
+  syncNoticeItemsFromConfig();
   modified.value = false;
   nextTick(() => {
     modified.value = false;
@@ -837,7 +910,14 @@ const submit = async () => {
   }
 
   if (mod.noticeIds) {
-    mod.noticeIds = cloneDeep(config.value.noticeIds);
+    mod.noticeIds = fromNoticeItems(noticeItems.value);
+  } else {
+    // 后端未在原 config 中出现该字段时，强制以 UI 状态同步。
+    const next = fromNoticeItems(noticeItems.value);
+    const prev = cloneDeep(store.curDice.config.noticeIds ?? []);
+    if (JSON.stringify(next) !== JSON.stringify(prev)) {
+      mod.noticeIds = next;
+    }
   }
 
   if (mod.extDefaultSettings) {

--- a/src/components/misc/PageMiscSettings.vue
+++ b/src/components/misc/PageMiscSettings.vue
@@ -98,31 +98,50 @@
           :key="index"
           v-for="(item, index) in noticeItems"
           style="width: 100%; margin-bottom: 0.5rem">
-          <div style="display: flex; align-items: center; gap: 0.5rem">
-            <el-checkbox v-model="item.enabled" :disabled="isMailNoticeItem(item.id)" />
+          <div class="notice-item-row">
             <el-input
               v-model="item.id"
+              class="notice-id-input"
               :autosize="true"
               :placeholder="noticeItemPlaceholder"
-              style="flex: 1"
               @change="onNoticeItemIdChanged(item)" />
+            <el-checkbox
+              v-model="item.enabled"
+              class="notice-enabled-checkbox"
+              :disabled="isMailNoticeItem(item.id)"
+              >启用</el-checkbox
+            >
             <el-select
               v-model="item.categories"
+              class="notice-category-select"
               multiple
               collapse-tags
               collapse-tags-tooltip
               :disabled="!item.enabled || isMailNoticeItem(item.id)"
-              placeholder="通知分类"
-              style="width: 18rem"
+              :placeholder="item.categoriesDirty ? '未选择分类' : '全部'"
+              popper-class="notice-category-popper"
               @change="markCategoriesDirty(item)">
               <el-option
                 v-for="option in noticeCategoryOptions"
                 :key="option.value"
                 :label="option.label"
                 :value="option.value">
-                <div style="display: flex; flex-direction: column; line-height: 1.2">
+                <div
+                  style="
+                    display: flex;
+                    width: 100%;
+                    flex-direction: column;
+                    align-items: flex-start;
+                    text-align: left;
+                    line-height: 1.2;
+                  ">
                   <span>{{ option.label }}</span>
-                  <el-text type="info" size="small">{{ option.description }}</el-text>
+                  <el-text
+                    type="info"
+                    size="small"
+                    style="align-self: flex-start; text-align: left"
+                    >{{ option.description }}</el-text
+                  >
                 </div>
               </el-option>
             </el-select>
@@ -843,7 +862,7 @@ const beforeUpload = async (file: any) => {
 };
 
 watch(
-  () => config,
+  [config, noticeItems],
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   (newValue, oldValue) => {
     //直接监听
@@ -1000,5 +1019,36 @@ const mailTest = async () => {
 .top-item {
   flex: 1 0 50%;
   flex-grow: 0;
+}
+
+.notice-item-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.notice-id-input {
+  min-width: 12rem;
+  max-width: 24rem;
+  flex: 0 1 24rem;
+}
+
+.notice-enabled-checkbox {
+  flex: none;
+  margin-right: 0;
+}
+
+.notice-category-select {
+  width: 18rem;
+  flex: 0 0 18rem;
+}
+
+:global(.notice-category-popper .el-select-dropdown__item) {
+  height: auto;
+  min-height: 34px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  text-align: left;
 }
 </style>


### PR DESCRIPTION
效果预览：

<img width="1007" height="478" alt="image" src="https://github.com/user-attachments/assets/39cd0492-1c08-4f4f-8723-5686817ea982" />

## Summary by Sourcery

在保持后端配置向后兼容的前提下，新增可配置的通知目标，每个条目支持独立启用开关和分类过滤。

新特性：
- 在“杂项设置”界面中引入结构化的通知目标项，每个目标支持单独启用/禁用以及分类选择。
- 新增通知编解码工具，用于对包含禁用状态和分类元数据的通知目标进行编码/解码，以便在后端持久化存储。

改进：
- 优化通知配置界面的布局、占位文本和工具提示，以澄清支持的前缀和分类行为。
- 确保通知配置更改在 UI 状态与已存储配置之间保持同步，即使之前不存在 `noticeIds` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable notice targets with per-item enable switches and category filters while keeping backend config backward compatible.

New Features:
- Introduce structured notice target items with per-target enable/disable and category selection in the miscellaneous settings UI.
- Add a notice codec utility to encode/decode notice targets with disable and category metadata for backend persistence.

Enhancements:
- Refine the notice configuration UI layout, placeholders, and tooltips to clarify supported prefixes and category behavior.
- Ensure notice configuration changes stay synchronized between the UI state and stored config, even when the noticeIds field was previously absent.

</details>

新功能：
- 在“杂项设置”界面中，为每个通知目标新增启用/禁用开关和分类选择。
- 添加编解码工具，用于解析和编码包含分类与禁用元数据的通知目标字符串，以便后端使用。

改进：
- 优化通知配置界面的布局、占位符和工具提示，更清晰地描述支持的前缀和分类行为。
- 确保通知配置的更改在 UI 状态和已存储配置之间保持同步，即使该字段此前不存在。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持后端配置向后兼容的前提下，新增可配置的通知目标，每个条目支持独立启用开关和分类过滤。

新特性：
- 在“杂项设置”界面中引入结构化的通知目标项，每个目标支持单独启用/禁用以及分类选择。
- 新增通知编解码工具，用于对包含禁用状态和分类元数据的通知目标进行编码/解码，以便在后端持久化存储。

改进：
- 优化通知配置界面的布局、占位文本和工具提示，以澄清支持的前缀和分类行为。
- 确保通知配置更改在 UI 状态与已存储配置之间保持同步，即使之前不存在 `noticeIds` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable notice targets with per-item enable switches and category filters while keeping backend config backward compatible.

New Features:
- Introduce structured notice target items with per-target enable/disable and category selection in the miscellaneous settings UI.
- Add a notice codec utility to encode/decode notice targets with disable and category metadata for backend persistence.

Enhancements:
- Refine the notice configuration UI layout, placeholders, and tooltips to clarify supported prefixes and category behavior.
- Ensure notice configuration changes stay synchronized between the UI state and stored config, even when the noticeIds field was previously absent.

</details>

</details>