### PR TITLE
feat: 添加托盘提示文本设置

### DIFF
--- a/src/api/dice/index.ts
+++ b/src/api/dice/index.ts
@@ -75,6 +75,7 @@ export type DiceConfig = {
   helpDocEngineType: number; // 帮助文档引擎类型
   masterUnlockCode: string; // 主解锁码
   serveAddress: string; // 服务器地址
+  trayTooltip: string; // 系统托盘提示文本
   masterUnlockCodeTime: number; // 解锁码的时间戳
   logPageItemLimit: number; // 日志页面的条目限制
   friendAddComment: string; // 添加好友时的备注

--- a/src/api/dice/index.ts
+++ b/src/api/dice/index.ts
@@ -75,7 +75,7 @@ export type DiceConfig = {
   helpDocEngineType: number; // 帮助文档引擎类型
   masterUnlockCode: string; // 主解锁码
   serveAddress: string; // 服务器地址
-  trayTooltip: string; // 系统托盘提示文本
+  trayTooltip?: string; // 系统托盘提示文本
   masterUnlockCodeTime: number; // 解锁码的时间戳
   logPageItemLimit: number; // 日志页面的条目限制
   friendAddComment: string; // 添加好友时的备注

--- a/src/components/misc/PageMiscSettings.vue
+++ b/src/components/misc/PageMiscSettings.vue
@@ -435,6 +435,26 @@
       </el-autocomplete>
     </el-form-item>
 
+    <el-form-item label="托盘提示文本">
+      <template #label>
+        <div>
+          <span>托盘提示文本</span>
+          <el-tooltip content="留空时使用“海豹TRPG骰点核心”，版本号和端口会自动追加">
+            <el-icon><question-filled /></el-icon>
+          </el-tooltip>
+        </div>
+      </template>
+      <div>
+        <el-input
+          v-model="config.trayTooltip"
+          clearable
+          placeholder="海豹TRPG骰点核心"
+          style="width: 14rem"
+          @input="config.trayTooltip = limitTrayTooltip(config.trayTooltip)" />
+        <el-text size="small" style="margin-left: 0.5rem"> {{ trayTooltipLength }}/10 </el-text>
+      </div>
+    </el-form-item>
+
     <el-form-item label="UI界面密码">
       <template #label>
         <div>
@@ -752,6 +772,12 @@ const store = useStore();
 
 const config = ref<any>({});
 const fileList = ref<any[]>([]);
+
+const limitTrayTooltip = (value: string | undefined) =>
+  Array.from(value ?? '')
+    .slice(0, 10)
+    .join('');
+const trayTooltipLength = computed(() => Array.from(config.value.trayTooltip ?? '').length);
 
 const isShowUnlockCode = ref(false);
 const modified = ref(false);

--- a/src/components/misc/PageMiscSettings.vue
+++ b/src/components/misc/PageMiscSettings.vue
@@ -452,7 +452,8 @@
       <template #label>
         <div>
           <span>托盘提示文本</span>
-          <el-tooltip content="留空时使用“海豹TRPG骰点核心”，版本号和端口会自动追加">
+          <el-tooltip
+            :content="`自定义前缀最长${trayTooltipMaxLength}个字符；留空时使用“海豹TRPG骰点核心”，版本号和端口会自动追加`">
             <el-icon><question-filled /></el-icon>
           </el-tooltip>
         </div>
@@ -462,9 +463,9 @@
           v-model="config.trayTooltip"
           clearable
           placeholder="海豹TRPG骰点核心"
-          style="width: 14rem"
-          @input="config.trayTooltip = limitTrayTooltip(config.trayTooltip)" />
-        <el-text size="small" style="margin-left: 0.5rem"> {{ trayTooltipLength }}/10 </el-text>
+          show-word-limit
+          :maxlength="trayTooltipMaxLength"
+          style="width: 14rem" />
       </div>
     </el-form-item>
 
@@ -773,11 +774,7 @@ const store = useStore();
 const config = ref<any>({});
 const fileList = ref<any[]>([]);
 
-const limitTrayTooltip = (value: string | undefined) =>
-  Array.from(value ?? '')
-    .slice(0, 10)
-    .join('');
-const trayTooltipLength = computed(() => Array.from(config.value.trayTooltip ?? '').length);
+const trayTooltipMaxLength = 10;
 
 const isShowUnlockCode = ref(false);
 const modified = ref(false);

--- a/src/components/misc/PageMiscSettings.vue
+++ b/src/components/misc/PageMiscSettings.vue
@@ -435,6 +435,19 @@
       </el-autocomplete>
     </el-form-item>
 
+    <el-form-item label="UI界面密码">
+      <template #label>
+        <div>
+          <span>UI 界面密码</span>
+          <el-tooltip content="公网用户一定要加，登录后会自动记住一段时间！">
+            <el-icon><question-filled /></el-icon>
+          </el-tooltip>
+        </div>
+      </template>
+
+      <el-input v-model="config.uiPassword" type="password" show-password style="width: auto" />
+    </el-form-item>
+
     <el-form-item label="托盘提示文本">
       <template #label>
         <div>
@@ -453,19 +466,6 @@
           @input="config.trayTooltip = limitTrayTooltip(config.trayTooltip)" />
         <el-text size="small" style="margin-left: 0.5rem"> {{ trayTooltipLength }}/10 </el-text>
       </div>
-    </el-form-item>
-
-    <el-form-item label="UI界面密码">
-      <template #label>
-        <div>
-          <span>UI 界面密码</span>
-          <el-tooltip content="公网用户一定要加，登录后会自动记住一段时间！">
-            <el-icon><question-filled /></el-icon>
-          </el-tooltip>
-        </div>
-      </template>
-
-      <el-input v-model="config.uiPassword" type="password" show-password style="width: auto" />
     </el-form-item>
 
     <h2>QQ 频道设置</h2>


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

为系统托盘提示文本添加可自定义的配置支持。

新功能：
- 引入新的 `trayTooltip` 配置字段，用于设置系统托盘提示文本。
- 在“杂项设置”页面中提供托盘提示文本输入框，并带有字符限制和长度显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在杂项设置和配置模式中添加可配置的系统托盘提示文本。

新特性：
- 引入 `trayTooltip` 配置字段，用于控制系统托盘提示文本。
- 在“杂项设置”页面中提供托盘提示文本输入框，带有长度限制和实时字符计数显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable system tray tooltip text to the miscellaneous settings and configuration schema.

New Features:
- Introduce a trayTooltip configuration field to control the system tray tooltip text.
- Expose a tray tooltip text input in the Misc Settings page with length limiting and live character count display.

</details>

</details>