### PR TITLE
feat(群组管理): 支持显示 QQ 官方机器人

### DIFF
--- a/src/components/misc/PageMiscGroup.vue
+++ b/src/components/misc/PageMiscGroup.vue
@@ -52,7 +52,6 @@
                     trigger="click"
                     :show-after="100">
                     <el-text
-                      :title="item.data.groupId"
                       style="
                         max-width: 23rem;
                         overflow: hidden;

--- a/src/components/misc/PageMiscGroup.vue
+++ b/src/components/misc/PageMiscGroup.vue
@@ -46,17 +46,24 @@
                   "
                   @click="item.data.changed = true" />
                 <el-space size="small" wrap>
-                  <el-text
-                    style="
-                      max-width: 23rem;
-                      overflow: hidden;
-                      white-space: nowrap;
-                      text-overflow: ellipsis;
-                    "
-                    size="large"
-                    tag="strong"
-                    >{{ item.data.groupId }}</el-text
-                  >
+                  <el-tooltip
+                    :content="item.data.groupId"
+                    placement="top"
+                    trigger="click"
+                    :show-after="100">
+                    <el-text
+                      :title="item.data.groupId"
+                      style="
+                        max-width: 23rem;
+                        overflow: hidden;
+                        white-space: nowrap;
+                        text-overflow: ellipsis;
+                      "
+                      size="large"
+                      tag="strong"
+                      >{{ item.data.groupId }}</el-text
+                    >
+                  </el-tooltip>
                   <el-text>「{{ item.data.groupName || '未获取到' }}」</el-text>
                 </el-space>
               </el-space>

--- a/src/components/misc/PageMiscGroup.vue
+++ b/src/components/misc/PageMiscGroup.vue
@@ -5,7 +5,9 @@
     <span style="margin-right: -0.2rem">
       <el-checkbox-group v-model="checkList">
         <el-checkbox label="QQ-Group:">QQ 群</el-checkbox>
+        <el-checkbox label="OpenQQ-Group:">QQ 官方机器人群</el-checkbox>
         <el-checkbox label="QQ-CH-Group:">QQ 频道</el-checkbox>
+        <el-checkbox label="OpenQQCH-Channel:">QQ 官方机器人频道</el-checkbox>
         <el-checkbox label="DISCORD-CH-Group:">Discord 频道</el-checkbox>
         <el-checkbox label="DODO-Group:">Dodo 频道</el-checkbox>
         <el-checkbox label="KOOK-CH-Group:">KOOK 频道</el-checkbox>


### PR DESCRIPTION
close https://github.com/sealdice/sealdice-core/issues/1782

## 由 Sourcery 提供的摘要

在群组管理页面中新增对 QQ 官方机器人群组和频道的管理与查看支持。

新功能：
- 在群组管理视图中新增 QQ 官方机器人群组和 QQ 官方机器人频道的筛选器。

改进：
- 优化群组 ID 显示方式，使用省略号并提供可点击的气泡提示，以查看完整标识符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for managing and viewing QQ official bot groups and channels in the group management page.

New Features:
- Add filters for QQ official bot groups and QQ official bot channels in the group management view.

Enhancements:
- Improve group ID display with an ellipsis and clickable tooltip to view the full identifier.

</details>

新功能：
- 在群组管理视图中公开用于筛选 QQ 官方机器人群组和频道的过滤器。

改进：
- 使用提示气泡（tooltip）包裹较长的群组 ID，使其在不破坏布局的前提下可以完整查看。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在群组管理页面中新增对 QQ 官方机器人群组和频道的管理与查看支持。

新功能：
- 在群组管理视图中新增 QQ 官方机器人群组和 QQ 官方机器人频道的筛选器。

改进：
- 优化群组 ID 显示方式，使用省略号并提供可点击的气泡提示，以查看完整标识符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for managing and viewing QQ official bot groups and channels in the group management page.

New Features:
- Add filters for QQ official bot groups and QQ official bot channels in the group management view.

Enhancements:
- Improve group ID display with an ellipsis and clickable tooltip to view the full identifier.

</details>

</details>